### PR TITLE
Define PICMI constants

### DIFF
--- a/Docs/source/how_to_use/implementing.rst
+++ b/Docs/source/how_to_use/implementing.rst
@@ -20,9 +20,9 @@ the following step:
 
 - Define the variable ``picmi.codename`` as a string containing the name of the code.
 
-- Create a sub-module ``picmi.constants``, that defines the constants described in :doc:`../standard/constants.rst`.
+- Create a sub-module ``picmi.constants``, that defines the constants described in :doc:`../standard/constants`.
 
-- Define the **PICMI classes** that a user of this code would typically us, among those defined in :doc:`../standard`.
+- Define the **PICMI classes** that a user of this code would typically us, among those defined in :doc:`../standard/standard`.
 
     This is should be done by defining a subclass of the corresponding class in the package ``picmistandard``,
     and defining its ``init`` method. For instance:
@@ -37,3 +37,11 @@ the following step:
 
                 # Code-specific initialization
                 self.initialized_space_charge_sources = False
+
+.. note::
+
+    For concrete examples on how to implement the PICMI standard, see the implementation in:
+
+        - `WarpX <https://github.com/ECP-WarpX/WarpX/blob/master/Python/pywarpx/picmi.py>`__
+        - `Warp <https://bitbucket.org/berkeleylab/warp/src/master/scripts/picmi.py>`__
+        - `FBPIC <https://github.com/fbpic/fbpic/tree/dev/fbpic/picmi>`__

--- a/Docs/source/how_to_use/implementing.rst
+++ b/Docs/source/how_to_use/implementing.rst
@@ -22,9 +22,9 @@ the following step:
 
 - Create a sub-module ``picmi.constants``, that defines the constants described in :doc:`../standard/constants`.
 
-- Define the **PICMI classes** that a user of this code would typically us, among those defined in :doc:`../standard/standard`.
+- Define the **PICMI classes** that a user of this code would typically use, among those defined in :doc:`../standard/standard`.
 
-    This is should be done by defining a subclass of the corresponding class in the package ``picmistandard``,
+    This should be done by defining a subclass of the corresponding class in the package ``picmistandard``,
     and defining its ``init`` method. For instance:
 
     ::

--- a/Docs/source/how_to_use/implementing.rst
+++ b/Docs/source/how_to_use/implementing.rst
@@ -5,5 +5,35 @@ Implementing the PICMI standard in an existing code
 
    This section is currently in development.
 
-   TODO: Explain that each code must implement subclasses of the PICMI classes,
-   and redefine the `init` method.
+In order to implement the PICMI standard, a given code should go through
+the following step:
+
+- Define a **Python package** (ideally, whose name is the name of the code itself), which contains a module ``picmi``:
+
+    The ``picmi`` module should be importable with the following syntax:
+
+    ::
+
+        from <python_package> import picmi
+
+    where ``<python_package>`` should be replaced by the name of the code.
+
+- Define the variable ``picmi.codename`` as a string containing the name of the code.
+
+- Create a sub-module ``picmi.constants``, that defines the constants described in :doc:`../standard/constants.rst`.
+
+- Define the **PICMI classes** that a user of this code would typically us, among those defined in :doc:`../standard`.
+
+    This is should be done by defining a subclass of the corresponding class in the package ``picmistandard``,
+    and defining its ``init`` method. For instance:
+
+    ::
+
+        import picmistandard
+
+        class Simulation( picmistandard.PICMI_Simulation ):
+
+            def init(self, kw):
+
+                # Code-specific initialization
+                self.initialized_space_charge_sources = False

--- a/Docs/source/standard/constants.rst
+++ b/Docs/source/standard/constants.rst
@@ -1,0 +1,13 @@
+Constants
+=========
+
+For convenience, the PICMI interface defines the following constants,
+which can be used directly inside any PICMI script.
+
+- ``picmi.constants.c``: The speed of light in vacuum.
+- ``picmi.constants.ep0``: The vacuum permittivity :math:`\epsilon_0`
+- ``picmi.constants.mu0``: The vacuum permeability :math:`\mu_0`
+- ``picmi.constants.q_e``: The elementary charge (absolute value of the charge of an electron).
+- ``picmi.constants.m_e``: The electron mass
+- ``picmi.constants.m_p``: The proton mass
+- ``picmi.constants.pi``: The number :math:`\pi`.

--- a/Docs/source/standard/constants.rst
+++ b/Docs/source/standard/constants.rst
@@ -2,7 +2,7 @@ Constants
 =========
 
 For convenience, the PICMI interface defines the following constants,
-which can be used directly inside any PICMI script.
+which can be used directly inside any PICMI script. The values are in SI units.
 
 - ``picmi.constants.c``: The speed of light in vacuum.
 - ``picmi.constants.ep0``: The vacuum permittivity :math:`\epsilon_0`
@@ -10,4 +10,3 @@ which can be used directly inside any PICMI script.
 - ``picmi.constants.q_e``: The elementary charge (absolute value of the charge of an electron).
 - ``picmi.constants.m_e``: The electron mass
 - ``picmi.constants.m_p``: The proton mass
-- ``picmi.constants.pi``: The number :math:`\pi`.

--- a/Docs/source/standard/standard.rst
+++ b/Docs/source/standard/standard.rst
@@ -16,6 +16,7 @@ Simulation and grid setup
    simulation
    field
    grid
+   constants
 
 Particles
 ---------

--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -14,11 +14,12 @@ cst = picmi.constants
 # ------------------
 
 # --- laser
+import math
+laser_polarization   = math.pi/2 # Polarization angle (in rad)
 laser_a0             = 4.        # Normalized potential vector
 laser_wavelength     = 8e-07     # Wavelength of the laser (in meters)
 laser_waist          = 5e-06     # Waist of the laser (in meters)
 laser_duration       = 15e-15    # Duration of the laser (in seconds)
-laser_polarization   = cst.pi/2. # Polarization angle (in rad)
 laser_injection_loc  = 9.e-6     # Position of injection (in meters, along z)
 laser_focal_distance = 100.e-6   # Focal distance from the injection (in meters)
 laser_t_peak         = 30.e-15   # The time at which the laser reaches its peak


### PR DESCRIPTION
This PR augments the PICMI documentation by:
- Listing the constants that PICMI should define
- Explicitly stating that each code should define these constants (i.e. they will not be in the `picmistandard` package)