### PR TITLE
Fixes to laser_acceleration_PICMI.py example

### DIFF
--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -174,9 +174,7 @@ part_diag = picmi.ParticleDiagnostic(period = 100,
 
 # Initialize the simulation object
 # Note that the time step size is obtained from the solver
-sim = picmi.Simulation(solver = solver,
-                       max_steps = max_steps,
-                       verbose = 1)
+sim = picmi.Simulation(solver = solver, verbose = 1)
 
 # Inject the laser through an antenna
 antenna = picmi.LaserAntenna(
@@ -194,7 +192,11 @@ sim.add_species(species=plasma, layout=plasma_layout)
 beam_layout = picmi.PseudoRandomLayout(
                 n_macroparticles = 10**5,
                 seed = 0)
-sim.add_species(species=beam, layout=beam_layout, initialize_self_field=False)
+initialize_self_field = True
+if picmi.codename != 'warpx':
+    initialize_self_field = False
+sim.add_species(species=beam, layout=beam_layout, 
+                initialize_self_field=initialize_self_field)
 
 # Add the diagnostics
 sim.add_diagnostic(field_diag)
@@ -207,8 +209,9 @@ run_python_simulation = True
 
 if run_python_simulation:
     # `sim.step` will run the code, controlling it from Python
-    sim.step()
+    sim.step(max_steps)
 else:
     # `write_inputs` will create an input file that can be used to run
     # with the compiled version.
+    sim.set_max_step(max_steps)
     sim.write_input_file(file_name='input_script')

--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -193,7 +193,7 @@ beam_layout = picmi.PseudoRandomLayout(
                 n_macroparticles = 10**5,
                 seed = 0)
 initialize_self_field = True
-if picmi.codename != 'warpx':
+if picmi.codename == 'warpx':
     initialize_self_field = False
 sim.add_species(species=beam, layout=beam_layout, 
                 initialize_self_field=initialize_self_field)

--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -108,7 +108,7 @@ plasma = picmi.MultiSpecies(
 # (if the user provided a name)
 # Set the ionization for the species number 1 (Argon)
 # and place the created electrons into the species number 2 (electron)
-if picmi.codename != 'pywarpx':
+if picmi.codename != 'warpx':
     plasma['Argon'].activate_field_ionization(
         model           = "ADK", # Ammosov-Delone-Krainov model
         product_species = plasma['e-'])
@@ -174,7 +174,9 @@ part_diag = picmi.ParticleDiagnostic(period = 100,
 
 # Initialize the simulation object
 # Note that the time step size is obtained from the solver
-sim = picmi.Simulation(solver=solver, verbose=1)
+sim = picmi.Simulation(solver = solver,
+                       max_steps = max_steps,
+                       verbose = 1)
 
 # Inject the laser through an antenna
 antenna = picmi.LaserAntenna(
@@ -192,7 +194,7 @@ sim.add_species(species=plasma, layout=plasma_layout)
 beam_layout = picmi.PseudoRandomLayout(
                 n_macroparticles = 10**5,
                 seed = 0)
-sim.add_species(species=beam, layout=beam_layout, initialize_self_field=True)
+sim.add_species(species=beam, layout=beam_layout, initialize_self_field=False)
 
 # Add the diagnostics
 sim.add_diagnostic(field_diag)
@@ -205,9 +207,8 @@ run_python_simulation = True
 
 if run_python_simulation:
     # `sim.step` will run the code, controlling it from Python
-    sim.step(max_steps)
+    sim.step()
 else:
     # `write_inputs` will create an input file that can be used to run
     # with the compiled version.
-    sim.set_max_step(max_steps)
     sim.write_input_file(file_name='input_script')

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -22,6 +22,7 @@ class PICMI_Species(_ClassWithInit):
       - charge=None: Particle charge, required when type is not specified, otherwise determined from type [C]
       - mass=None: Particle mass, required when type is not specified, otherwise determined from type [kg]
       - initial_distribution=None: The initial distribution loaded at t=0. Must be one of the standard distributions implemented.
+      - density_scale=None: A scale factor on the density given by the initial_distribution (optional)
       - particle_shape: Particle shape used for deposition and gather ; if None, the default from the `Simulation` object will be used. Possible values are 'NGP', 'linear', 'quadratic', 'cubic'
     """
 


### PR DESCRIPTION
A few suggested changes to the example.

The biggest change is setting initialize_self_field=False since it is not supported by WarpX yet (correct?).