### PR TITLE
Fixed moving window in RZ in LWFA example

### DIFF
--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -39,14 +39,6 @@ bunch_centroid_velocity   = [0.,0.,1000.*cst.c]
 # Numerics parameters
 # -------------------
 
-# --- geometry and solver
-em_solver_method = 'CKC'
-geometry = '3D'
-# Note that code-specific changes can be introduced with `picmi.codename`
-if picmi.codename == 'fbpic':
-    em_solver_method = 'PSATD'
-    geometry = 'RZ'
-
 # --- Nb time steps
 max_steps = 1000
 
@@ -148,7 +140,7 @@ elif geometry == 'RZ':
         lower_boundary_conditions = [ None, 'open'],
         upper_boundary_conditions = ['reflective', 'open'],
         n_azimuthal_modes         = 2,
-        moving_window_velocity    = moving_window_velocity,
+        moving_window_velocity    = moving_window_velocity[-1],
         warpx_max_grid_size       = 32)
 
 smoother = picmi.BinomialSmoother( n_pass       = 1,


### PR DESCRIPTION
This PR contains the following changes to the *laser acceleration* example:
- removed duplicate lines 
- fixed call to `moving_window_velocity` parameter, which is a scalar (z direction velocity) in RZ.