### PR TITLE
Added checking of input arguments

### DIFF
--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -3,20 +3,34 @@
 
 codename = None
 
+# --- The list of supported codes is needed to allow checking for bad arguments.
+supported_codes = ['warp', 'warpx', 'fbpic']
+
 def register_codename(_codename):
     global codename
     codename = _codename
 
 class _ClassWithInit(object):
     def handle_init(self, kw):
+        # --- Grab all keywords for the current code.
+        # --- Arguments for other supported codes are ignored.
+        # --- If there is anything left over, it is an error.
         codekw = {}
-        for k,v in kw.items():
-            if k.startswith(codename + '_'):
+        for k,v in kw.copy().items():
+            code = k.split('_')[0]
+            if code == codename:
                 codekw[k] = v
+            if code in supported_codes:
+                kw.pop(k)
 
+        if kw:
+            raise TypeError('Unexpected keyword argument: "%s"'%list(kw))
+
+        # --- It is expected that init strips accepted keywords from codekw.
         self.init(codekw)
+
         if codekw:
-            raise TypeError("got an unexpected keyword argument '%s'"%list(codekw)[0])
+            raise TypeError("Unexpected keyword argument for %s: '%s'"%(codename, list(codekw)))
 
     def init(self, kw):
         # --- The implementation of this routine should use kw.pop() to retrieve input arguments from kw.


### PR DESCRIPTION
A major weakness has been the lack of argument checks in picmi input files. This fixes the issue.

An important piece of this is having a list of supported codes, so that arguments for those codes can be ignored. Are there other codes to add to the list?