### PR TITLE
Removed SciPy references

### DIFF
--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -14,15 +14,15 @@ def register_codename(_codename):
 # --- This needs to be set by the implementing package (by calling register_constants).
 # --- It allows constants to be used within the picmi interface, with the constants
 # --- defined in the implementation.
-implementation_constants = None
+_implementation_constants = None
 
-def register_constants(_implementation_constants):
+def register_constants(implementation_constants):
     """This must be called by the implementing code, passing in the constans object"""
-    global implementation_constants
-    implementation_constants = _implementation_constants
+    global _implementation_constants
+    _implementation_constants = implementation_constants
 
 def _get_constants():
-    return implementation_constants
+    return _implementation_constants
 
 class _ClassWithInit(object):
     def handle_init(self, kw):

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -7,8 +7,22 @@ codename = None
 supported_codes = ['warp', 'warpx', 'fbpic']
 
 def register_codename(_codename):
+    """This must be called by the implementing code, passing in the code name"""
     global codename
     codename = _codename
+
+# --- This needs to be set by the implementing package (by calling register_constants).
+# --- It allows constants to be used within the picmi interface, with the constants
+# --- defined in the implementation.
+implementation_constants = None
+
+def register_constants(_implementation_constants):
+    """This must be called by the implementing code, passing in the constans object"""
+    global implementation_constants
+    implementation_constants = _implementation_constants
+
+def _get_constants():
+    return implementation_constants
 
 class _ClassWithInit(object):
     def handle_init(self, kw):

--- a/PICMI_Python/lasers.py
+++ b/PICMI_Python/lasers.py
@@ -5,7 +5,7 @@ import math
 import sys
 import re
 
-from .base import _ClassWithInit
+from .base import _ClassWithInit, _get_constants
 
 # ---------------
 # Physics objects
@@ -51,11 +51,9 @@ class PICMI_GaussianLaser(_ClassWithInit):
 
         k0 = 2.*math.pi/wavelength
         if E0 is None:
-            from scipy import constants
-            E0 = a0*constants.electron_mass*constants.speed_of_light**2*k0/constants.elementary_charge
+            E0 = a0*_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e
         if a0 is None:
-            from scipy import constants
-            a0 = E0/(constants.electron_mass*constants.speed_of_light**2*k0/constants.elementary_charge)
+            a0 = E0/(_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e)
 
         self.wavelength = wavelength
         self.k0 = k0
@@ -112,11 +110,9 @@ class PICMI_AnalyticLaser(_ClassWithInit):
 
         k0 = 2.*math.pi/wavelength
         if Emax is None:
-            from scipy import constants
-            Emax = amax*constants.electron_mass*constants.speed_of_light**2*k0/constants.elementary_charge
+            Emax = amax*_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e
         if amax is None:
-            from scipy import constants
-            amax = Emax/(constants.electron_mass*constants.speed_of_light**2*k0/constants.elementary_charge)
+            amax = Emax/(_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e)
 
         self.wavelength = wavelength
         self.field_expression = field_expression

--- a/PICMI_Python/setup.py
+++ b/PICMI_Python/setup.py
@@ -5,7 +5,7 @@
 from setuptools import setup
 
 setup(name = 'picmistandard',
-      version = '0.0.13',
+      version = '0.0.14',
       description = 'Python base classes for PICMI standard',
       platforms = 'any',
       packages = ['picmistandard'],

--- a/PICMI_Python/setup.py
+++ b/PICMI_Python/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup
 setup(name = 'picmistandard',
       version = '0.0.13',
       description = 'Python base classes for PICMI standard',
-      install_requires=['scipy~=1.6.0'],
       platforms = 'any',
       packages = ['picmistandard'],
       package_dir = {'picmistandard': '.'},


### PR DESCRIPTION
This removes the references to SciPy by allowing use of constants that are defined in the implementing code. The change adds `_implementation_constants` which is set by the implementing code by calling `register_constants`. Then internally, whenever a constant is needed, it should call `_get_constants()` to retrieve the implementation's constant object.

This avoids a potential problem created by having the constants defined in two different places, the implementing code and scipy. It is unlikely that there would be significant issue, but his avoids obscure problems that would arise if the constants in the two difference places have slightly different values.