### PR TITLE
setup.py: fix overspecification

### DIFF
--- a/PICMI_Python/setup.py
+++ b/PICMI_Python/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(name = 'picmistandard',
       version = '0.0.13',
       description = 'Python base classes for PICMI standard',
-      install_requires=['scipy~=1.6.0'],
+      install_requires=['scipy~=1.6'],
       platforms = 'any',
       packages = ['picmistandard'],
       package_dir = {'picmistandard': '.'},


### PR DESCRIPTION
I accidentally added the patch-level for version-compatible matching

This removes the patch-level for `~=` matching for the packages that have a >=1 major version already.

Ref.: https://www.python.org/dev/peps/pep-0440/#compatible-release

Follow-up to #34