### PR TITLE
scipy 1.5+

### DIFF
--- a/PICMI_Python/setup.py
+++ b/PICMI_Python/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 setup(name = 'picmistandard',
       version = '0.0.13',
       description = 'Python base classes for PICMI standard',
-      install_requires=['scipy~=1.6'],
+      install_requires=['scipy~=1.5'],
       platforms = 'any',
       packages = ['picmistandard'],
       package_dir = {'picmistandard': '.'},


### PR DESCRIPTION
Sufficient since it was last release in december and works well.
The 3.5 release series still builds wheels for Python 3.6 for Ubuntu oldstable (18.04).

Follow-up to #36 