### PR TITLE
Remove diagnostic defaults

### DIFF
--- a/PICMI_Python/README.md
+++ b/PICMI_Python/README.md
@@ -19,3 +19,41 @@ should take the inputs and convert them to the appropriate inputs for the specif
 **Warning:**
 The standard is still evolving at this point. The most basic components of the standard have been defined and are being refined. New components are being added.
 
+
+# For developers
+
+This directory is the Python version of the PICMI standard. The files contain the classes that form the standard. These files
+consist of picmistandard package.
+
+To submit changes, create a fork of the repo on github and create a new branch in the fork where the changes are to be made.
+When the changes are ready submit a pull request on github for review. If acceptable, the request will be merged in.
+
+Some packages specify the version of the standard that is to be used. For new features to be included, the version of picmi needs to
+be updated. The update has several steps, updating the version number, adding a tag, pushing the changes, and updating the version
+of PyPI.
+
+Currently, the version number is modified by hand by modifying the number in the setup.py file, incrementing the third
+number. After changing the file, make a commit with the change with a comment like "Version 0.0.16", updating the number of course.
+Please don't make any other changes in the commit. Note that it is ok to push a version update directly to the main branch assuming
+it has been approved.
+
+Next, add a tag and push the changes to the repo:
+
+  ```
+  git tag -a 0.0.16 -m "Release 0.0.16"
+  git push origin
+  git push origin --tags
+  ```
+
+Change the tag number as needed.
+
+The final step is to update the version on PyPI. It is recommended to use the twine command. Here are the commands:
+
+  ```
+  python setup.py sdist bdist_wheel
+  twine upload dist/*
+  ```
+
+The first builds the distribution, the second uploads it. Note that it is good practice to delete the dist directory
+afterwards so that each time uploads only the most recent version.
+

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -15,7 +15,7 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
     Defines the electromagnetic field diagnostics in the simulation frame
       - grid: Grid object for the diagnostic
       - period: Period of time steps that the diagnostic is performed
-      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "J", "Ex" etc.
+      - data_list: List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -41,6 +41,8 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
                  parallelio = None,
                  name = None,
                  **kw):
+
+        assert isinstance(data_list, list), 'FieldDiagnostic: data_list must be a list'
 
         self.grid = grid
         self.period = period
@@ -62,7 +64,7 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
     Defines the electrostatic field diagnostics in the simulation frame
       - grid: Grid object for the diagnostic
       - period: Period of time steps that the diagnostic is performed
-      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "Ex" etc.
+      - data_list: List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc.
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -87,6 +89,8 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
                  parallelio = None,
                  name = None,
                  **kw):
+
+        assert isinstance(data_list, list), 'ElectrostaticFieldDiagnostic: data_list must be a list'
 
         self.grid = grid
         self.period = period
@@ -109,7 +113,7 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
       - period: Period of time steps that the diagnostic is performed
       - species: Species or list of species to write out
                  Note that the name attribute must be defined for the species.
-      - data_list: The data to be written out. Possible values "position", "momentum", "weighting".
+      - data_list: The data to be written out. Possible values 'position', 'momentum', 'weighting'.
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -126,6 +130,8 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
                  parallelio = None,
                  name = None,
                  **kw):
+
+        assert isinstance(data_list, list), 'ParticleDiagnostic: data_list must be a list'
 
         self.period = period
         self.species = species
@@ -150,7 +156,7 @@ class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
       - grid: Grid object for the diagnostic
       - num_snapshots: Number of lab frame snapshots to make
       - dt_snapshots: Time between each snapshot in lab frame
-      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "J", "Ex" etc.
+      - data_list: List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
       - z_subsampling=1: A factor which is applied on the resolution of the lab frame reconstruction. (integer)
       - time_start=0.: Time for the first snapshot in lab frame
       - write_dir='.': Directory where data is to be written
@@ -163,6 +169,8 @@ class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
                  parallelio = None,
                  name = None,
                  **kw):
+
+        assert isinstance(data_list, list), 'LabFrameFieldDiagnostic: data_list must be a list'
 
         self.grid = grid
         self.num_snapshots = num_snapshots
@@ -183,7 +191,7 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
       - grid: Grid object for the diagnostic
       - num_snapshots: Number of lab frame snapshots to make
       - dt_snapshots: Time between each snapshot in lab frame
-      - data_list: The data to be written out. Possible values "position", "momentum", "weighting".
+      - data_list: The data to be written out. Possible values 'position', 'momentum', 'weighting'.
       - time_start=0.: Time for the first snapshot in lab frame
       - species: Species or list of species to write out
                  Note that the name attribute must be defined for the species.
@@ -198,6 +206,8 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
                  parallelio = None,
                  name = None,
                  **kw):
+
+        assert isinstance(data_list, list), 'LabFrameParticleDiagnostic: data_list must be a list'
 
         self.grid = grid
         self.num_snapshots = num_snapshots

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -14,8 +14,8 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
     """
     Defines the electromagnetic field diagnostics in the simulation frame
       - grid: Grid object for the diagnostic
-      - period=1: Period of time steps that the diagnostic is performed
-      - data_list=["rho", "E", "B", "J"]: List of quantities to write out
+      - period: Period of time steps that the diagnostic is performed
+      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "J", "Ex" etc.
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -31,8 +31,7 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
       - name: Sets the base name for the diagnostic output files (optional)
 
     """
-    def __init__(self, grid, period = 1,
-                 data_list = ["rho", "E", "B", "J"],
+    def __init__(self, grid, period, data_list,
                  write_dir = None,
                  step_min = None,
                  step_max = None,
@@ -62,8 +61,8 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
     """
     Defines the electrostatic field diagnostics in the simulation frame
       - grid: Grid object for the diagnostic
-      - period=1: Period of time steps that the diagnostic is performed
-      - data_list=["rho", "phi"]: List of quantities to write out
+      - period: Period of time steps that the diagnostic is performed
+      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "Ex" etc.
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -78,8 +77,7 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
       - parallelio=None: If set to True, field diagnostics are dumped in parallel (optional)
       - name: Sets the base name for the diagnostic output files (optional)
     """
-    def __init__(self, grid, period = 1,
-                 data_list = ["rho", "phi"],
+    def __init__(self, grid, period, data_list,
                  write_dir = None,
                  step_min = None,
                  step_max = None,
@@ -108,10 +106,10 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
 class PICMI_ParticleDiagnostic(_ClassWithInit) :
     """
     Defines the particle diagnostics in the simulation frame
-      - period=1: Period of time steps that the diagnostic is performed
+      - period: Period of time steps that the diagnostic is performed
       - species: Species or list of species to write out
                  Note that the name attribute must be defined for the species.
-      - data_list=["position", "momentum", "weighting"]: The data to be written out
+      - data_list: The data to be written out. Possible values "position", "momentum", "weighting".
       - write_dir='.': Directory where data is to be written
       - step_min=None: Minimum step at which diagnostics could be written (optional)
                        Defaults to step 0.
@@ -121,9 +119,7 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
       - name: Sets the base name for the diagnostic output files (optional)
     """
 
-    def __init__(self, period = 1,
-                 species = None,
-                 data_list = ["position", "momentum", "weighting"],
+    def __init__(self, period, species, data_list,
                  write_dir = None,
                  step_min = None,
                  step_max = None,
@@ -154,16 +150,15 @@ class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
       - grid: Grid object for the diagnostic
       - num_snapshots: Number of lab frame snapshots to make
       - dt_snapshots: Time between each snapshot in lab frame
+      - data_list: List of quantities to write out. Possible values "rho", "E", "B", "J", "Ex" etc.
       - z_subsampling=1: A factor which is applied on the resolution of the lab frame reconstruction. (integer)
       - time_start=0.: Time for the first snapshot in lab frame
-      - data_list=["rho", "E", "B", "J"]: List of quantities to write out
       - write_dir='.': Directory where data is to be written
       - parallelio=None: If set to True, field diagnostics are dumped in parallel (optional)
       - name: Sets the base name for the diagnostic output files (optional)
     """
-    def __init__(self, grid, num_snapshots, dt_snapshots,
+    def __init__(self, grid, num_snapshots, dt_snapshots, data_list,
                  z_subsampling = 1, time_start = 0.,
-                 data_list = ["rho", "E", "B", "J"],
                  write_dir = None,
                  parallelio = None,
                  name = None,
@@ -188,18 +183,17 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
       - grid: Grid object for the diagnostic
       - num_snapshots: Number of lab frame snapshots to make
       - dt_snapshots: Time between each snapshot in lab frame
+      - data_list: The data to be written out. Possible values "position", "momentum", "weighting".
       - time_start=0.: Time for the first snapshot in lab frame
       - species: Species or list of species to write out
                  Note that the name attribute must be defined for the species.
-      - data_list=["position", "momentum", "weighting"]: The data to be written out
       - write_dir='.': Directory where data is to be written
       - parallelio=None: If set to True, particle diagnostics are dumped in parallel (optional)
       - name: Sets the base name for the diagnostic output files (optional)
     """
-    def __init__(self, grid, num_snapshots, dt_snapshots,
+    def __init__(self, grid, num_snapshots, dt_snapshots, data_list,
                  time_start = 0.,
                  species = None,
-                 data_list = ["position", "momentum", "weighting"],
                  write_dir = None,
                  parallelio = None,
                  name = None,


### PR DESCRIPTION
In the diagnostics, the period was defaulted to 1 and the data_list for the fields and particles were specified. This PR removes those defaults and make `period` and 'data_list` required input parameters. This matches the desired behavior in WarpX and matches the overall structure of PICMI where in general default values are not given (relying on the defaults of the implementing codes).