### PR TITLE
Fix: Manifest

### DIFF
--- a/PICMI_Python/MANIFEST.in
+++ b/PICMI_Python/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include requirements.txt


### PR DESCRIPTION
Otherwise, files like `requirements.txt` are not packed and thus fail the install.

Follow-up to #39