### PR TITLE
Adds constants to plasmacode and updates example to use it

### DIFF
--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -2,7 +2,7 @@
 # e.g. `from pywarpx import picmi`
 #      `from fbpic import picmi`
 #      `from warp import picmi`
-from fbpic import picmi
+from plasmacode import picmi
 
 # Create alias fror constants
 cst = picmi.constants

--- a/Test/plasmacode/picmi/__init__.py
+++ b/Test/plasmacode/picmi/__init__.py
@@ -2,6 +2,19 @@ import picmistandard
 codename = 'plasmacode'
 picmistandard.register_codename(codename)
 
+class constants:
+    # --- Put the constants in their own namespace
+    c = 299792458.
+    ep0 = 8.8541878128e-12
+    mu0 = 1.25663706212e-06
+    q_e = 1.602176634e-19
+    m_e = 9.1093837015e-31
+    m_p = 1.67262192369e-27
+    hbar = 1.054571817e-34
+    kb = 1.380649e-23
+
+picmistandard.register_constants(constants)
+
 picmi_classes = [ cls for cls in picmistandard.__dir__() \
                       if cls.startswith('PICMI_') ]
 


### PR DESCRIPTION
The empty example `plasmacode` is updated to include definition of the `constants` namespace as now required by the standard.

This also modifies the example, `Examples/laser_acceleration/laser_acceleration_PICMI.py` so that it imports the `plasmacode` picmi module.

This fixes issue #62.