### PR TITLE
Handle unsupported

### DIFF
--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -55,7 +55,12 @@ class _ClassWithInit(object):
         pass
 
     def _check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
-        """Raise a warning or exception for an unsupported argument."""
+        """Raise a warning or exception for an unsupported argument.
+         - arg_name: The name of the unsupported argument (string)
+         - extra_info: Extra information to include in the warning/error message (string)
+         - raise_error: If False (the default), raise a warning. If true, raise an exception
+                        (which interrupts the code).
+        """
         # --- Implementation note: This should be called in the "init" method of the implementing
         # --- class for each unsupported argument. For example, for the 'density_scale' argument of Species:
         # ---     self._check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
@@ -74,7 +79,12 @@ class _ClassWithInit(object):
                 warnings.warn(message)
 
     def _unsupported_value(self, arg_name, extra_info='', raise_error=True):
-        """Raise a warning or exception for argument with an unsupported value."""
+        """Raise a warning or exception for argument with an unsupported value.
+         - arg_name: The name of the argument with an unsupported value (string)
+         - extra_info: Extra information to include in the warning/error message (string)
+         - raise_error: If False (the default), raise a warning. If true, raise an exception
+                        (which interrupts the code).
+        """
         # --- Implementation note: This should be called when the implementing code handles
         # --- the input arguments. For example, for 'method' in Species:
         # ---     if self.method not in ['Boris', 'Li']:

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -58,7 +58,12 @@ class _ClassWithInit(object):
         # --- Implementation note: This should be called in the "init" method of the implementing
         # --- class for each unsupported argument. For example, for the 'density_scale' argument of Species:
         # ---     self._check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
-        if getattr(self, arg_name) is not None:
+
+        # This compares the value of the parameter with the dault value in the __init__ method.
+        # If they differ, this means that the user supplied a value, so a warning or error is raised.
+        signature = inspect.signature(self.__init__)
+        default_value = signature.parameters[arg_name].default
+        if not (getattr(self, arg_name) == default_value):
             message = f'{self.__name__}: For argument {arg_name} is not supported.'
             if extra_info is not None:
                 message += f' {extra_info}'

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -85,15 +85,20 @@ class _ClassWithInit(object):
 
     def _unsupported_value(self, arg_name, extra_info='', raise_error=True):
         """Raise a warning or exception for argument with an unsupported value.
-         - arg_name: The name of the argument with an unsupported value (string)
-         - extra_info: Extra information to include in the warning/error message (string)
-         - raise_error: If False (the default), raise a warning. If true, raise an exception
-                        (which interrupts the code).
+
+
+        Implementation note: This should be called when the implementing code handles
+        the input arguments. For example, for 'method' in Species:
+            if self.method not in ['Boris', 'Li']:
+                self._unsupported_value(
+                    'method',
+                    extra_info='My code only supports Boris and Li')
+
+        - arg_name: The name of the argument with an unsupported value (string)
+        - extra_info: Extra information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
         """
-        # --- Implementation note: This should be called when the implementing code handles
-        # --- the input arguments. For example, for 'method' in Species:
-        # ---     if self.method not in ['Boris', 'Li']:
-        # ---         self._unsupported_value('method', extra_info='My code only supports Boris and Li')
         message = f'{self.__name__}: For argument {arg_name}, the value {getattr(self, arg_name)} is not supported.'
         if extra_info is not None:
             message += f' {extra_info}'

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -1,5 +1,6 @@
 """base code for the PICMI standard
 """
+import inspect
 import warnings
 
 codename = None

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -109,16 +109,20 @@ class _ClassWithInit(object):
 
     def _check_deprecated_argument(self, arg_name, extra_info=None, raise_error=False):
         """Raise a warning or exception if a deprecated argument was specified by the user
-         - arg_name: The name of the deprecated argument (string)
-         - extra_info: Extra information to include in the warning/error message (string)
-         - raise_error: If False (the default), raise a warning. If true, raise an exception
-                        (which interrupts the code).
+
+        Implementation note: This should be called within PICMI in the "__init__" method of classes
+        for each deprecated argument. This assumes that the argument is still included in the
+        argument list of __init__ as a transition until it is removed.
+        For example, if the 'density_scale' argument of Species was to be deprecated:
+            self._check_deprecated_argument(
+                'density_scale',
+                extra_info='This argument is no longer needed')
+
+        - arg_name: The name of the deprecated argument (string)
+        - extra_info: Extra information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
         """
-        # --- Implementation note: This should be called within PICMI in the "__init__" method of classes
-        # --- for each deprecated argument. This assumes that the argument is still included in the
-        # --- argument list of __init__ as a transition until it is removed.
-        # --- For example, if the 'density_scale' argument of Species was to be deprecated:
-        # ---     self._check_deprecated_argument('density_scale', extra_info='This argument is no longer needed')
 
         # This compares the value of the parameter with the dault value in the __init__ method.
         # If they differ, this means that the user supplied a value, so a warning or error is raised.

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -55,7 +55,7 @@ class _ClassWithInit(object):
         pass
 
     def _check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
-        """Raise a warning or exception for an unsupported argument.
+        """Raise a warning or exception if an unsupported argument was specified by the user
          - arg_name: The name of the unsupported argument (string)
          - extra_info: Extra information to include in the warning/error message (string)
          - raise_error: If False (the default), raise a warning. If true, raise an exception
@@ -96,4 +96,30 @@ class _ClassWithInit(object):
             raise Exception(message)
         else:
             warnings.warn(message)
+
+    def _check_deprecated_argument(self, arg_name, extra_info=None, raise_error=False):
+        """Raise a warning or exception if a deprecated argument was specified by the user
+         - arg_name: The name of the deprecated argument (string)
+         - extra_info: Extra information to include in the warning/error message (string)
+         - raise_error: If False (the default), raise a warning. If true, raise an exception
+                        (which interrupts the code).
+        """
+        # --- Implementation note: This should be called within PICMI in the "__init__" method of classes
+        # --- for each deprecated argument. This assumes that the argument is still included in the
+        # --- argument list of __init__ as a transition until it is removed.
+        # --- For example, if the 'density_scale' argument of Species was to be deprecated:
+        # ---     self._check_deprecated_argument('density_scale', extra_info='This argument is no longer needed')
+
+        # This compares the value of the parameter with the dault value in the __init__ method.
+        # If they differ, this means that the user supplied a value, so a warning or error is raised.
+        signature = inspect.signature(self.__init__)
+        default_value = signature.parameters[arg_name].default
+        if not (getattr(self, arg_name) == default_value):
+            message = f'{self.__name__}: For argument {arg_name} is not supported.'
+            if extra_info is not None:
+                message += f' {extra_info}'
+            if raise_error:
+                raise Exception(message)
+            else:
+                warnings.warn(message)
 

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -1,5 +1,6 @@
 """base code for the PICMI standard
 """
+import warnings
 
 codename = None
 
@@ -51,3 +52,30 @@ class _ClassWithInit(object):
         # --- The implementation of this routine should use kw.pop() to retrieve input arguments from kw.
         # --- This allows testing for any unused arguments and raising an error if found.
         pass
+
+    def check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
+        """Raise a warning or exception for an unsupported argument."""
+        # --- Implementation note: This should be called in the "init" method of the implementing
+        # --- class for each unsupported argument. For example, for the 'density_scale' argument of Species:
+        # ---     self.check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
+        if getattr(self, arg_name) is not None:
+            message = f'{self.__name__}: For argument {arg_name} is not supported.'
+            if extra_info is not None:
+                message += f' {extra_info}'
+            if raise_error:
+                raise Exception(message)
+            else:
+                warnings.warn(message)
+
+    def unsupported_value(self, arg_name, extra_info='', raise_error=True):
+        """Raise a warning or exception for argument with an unsupported value."""
+        # --- Implementation note: This should be called when the implementing code handles
+        # --- the input arguments. For example, for 'method' in Species:
+        # ---     if self.method not in ['Boris', 'Li']:
+        # ---         self.unsupported_value('method', extra_info='My code only supports Boris and Li')
+        message = f'{self.__name__}: For argument {arg_name}, the value {getattr(self, arg_name)} is not supported.'
+        if raise_error:
+            raise Exception(message)
+        else:
+            warnings.warn(message)
+

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -53,11 +53,11 @@ class _ClassWithInit(object):
         # --- This allows testing for any unused arguments and raising an error if found.
         pass
 
-    def check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
+    def _check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
         """Raise a warning or exception for an unsupported argument."""
         # --- Implementation note: This should be called in the "init" method of the implementing
         # --- class for each unsupported argument. For example, for the 'density_scale' argument of Species:
-        # ---     self.check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
+        # ---     self._check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
         if getattr(self, arg_name) is not None:
             message = f'{self.__name__}: For argument {arg_name} is not supported.'
             if extra_info is not None:
@@ -67,13 +67,15 @@ class _ClassWithInit(object):
             else:
                 warnings.warn(message)
 
-    def unsupported_value(self, arg_name, extra_info='', raise_error=True):
+    def _unsupported_value(self, arg_name, extra_info='', raise_error=True):
         """Raise a warning or exception for argument with an unsupported value."""
         # --- Implementation note: This should be called when the implementing code handles
         # --- the input arguments. For example, for 'method' in Species:
         # ---     if self.method not in ['Boris', 'Li']:
-        # ---         self.unsupported_value('method', extra_info='My code only supports Boris and Li')
+        # ---         self._unsupported_value('method', extra_info='My code only supports Boris and Li')
         message = f'{self.__name__}: For argument {arg_name}, the value {getattr(self, arg_name)} is not supported.'
+        if extra_info is not None:
+            message += f' {extra_info}'
         if raise_error:
             raise Exception(message)
         else:

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -54,20 +54,21 @@ class _ClassWithInit(object):
         # --- This allows testing for any unused arguments and raising an error if found.
         pass
 
-    def _check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
+    def _check_unsupported_argument(self, arg_name, message=None, raise_error=False):
         """Raise a warning or exception if an unsupported argument was specified by the user
+        - arg_name: The name of the unsupported argument (string)
+        - message: Information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
 
         Implementation note: This should be called in the "init" method of the
         implementing class for each unsupported argument. For example, for the
         'density_scale' argument of Species:
+
             self._check_unsupported_argument(
                 'density_scale',
-                extra_info='My code can not handle a density_scale')
+                message='My code can not handle a density_scale')
 
-        - arg_name: The name of the unsupported argument (string)
-        - extra_info: Extra information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
         """
 
         # This compares the value of the parameter with the dault value in the __init__ method.
@@ -76,52 +77,53 @@ class _ClassWithInit(object):
         default_value = signature.parameters[arg_name].default
         if not (getattr(self, arg_name) == default_value):
             message = f'{self.__name__}: For argument {arg_name} is not supported.'
-            if extra_info is not None:
-                message += f' {extra_info}'
+            if message is not None:
+                message += f' {message}'
             if raise_error:
                 raise Exception(message)
             else:
                 warnings.warn(message)
 
-    def _unsupported_value(self, arg_name, extra_info='', raise_error=True):
+    def _unsupported_value(self, arg_name, message='', raise_error=True):
         """Raise a warning or exception for argument with an unsupported value.
-
+        - arg_name: The name of the argument with an unsupported value (string)
+        - message: Information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
 
         Implementation note: This should be called when the implementing code handles
         the input arguments. For example, for 'method' in Species:
+
             if self.method not in ['Boris', 'Li']:
                 self._unsupported_value(
                     'method',
-                    extra_info='My code only supports Boris and Li')
+                    message='My code only supports Boris and Li')
 
-        - arg_name: The name of the argument with an unsupported value (string)
-        - extra_info: Extra information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
         """
         message = f'{self.__name__}: For argument {arg_name}, the value {getattr(self, arg_name)} is not supported.'
-        if extra_info is not None:
-            message += f' {extra_info}'
+        if message is not None:
+            message += f' {message}'
         if raise_error:
             raise Exception(message)
         else:
             warnings.warn(message)
 
-    def _check_deprecated_argument(self, arg_name, extra_info=None, raise_error=False):
+    def _check_deprecated_argument(self, arg_name, message=None, raise_error=False):
         """Raise a warning or exception if a deprecated argument was specified by the user
+        - arg_name: The name of the deprecated argument (string)
+        - message: Information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
 
         Implementation note: This should be called within PICMI in the "__init__" method of classes
         for each deprecated argument. This assumes that the argument is still included in the
         argument list of __init__ as a transition until it is removed.
         For example, if the 'density_scale' argument of Species was to be deprecated:
+
             self._check_deprecated_argument(
                 'density_scale',
-                extra_info='This argument is no longer needed')
+                message='This argument is no longer needed')
 
-        - arg_name: The name of the deprecated argument (string)
-        - extra_info: Extra information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
         """
 
         # This compares the value of the parameter with the dault value in the __init__ method.
@@ -130,8 +132,8 @@ class _ClassWithInit(object):
         default_value = signature.parameters[arg_name].default
         if not (getattr(self, arg_name) == default_value):
             message = f'{self.__name__}: For argument {arg_name} is not supported.'
-            if extra_info is not None:
-                message += f' {extra_info}'
+            if message is not None:
+                message += f' {message}'
             if raise_error:
                 raise Exception(message)
             else:

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -56,14 +56,19 @@ class _ClassWithInit(object):
 
     def _check_unsupported_argument(self, arg_name, extra_info=None, raise_error=False):
         """Raise a warning or exception if an unsupported argument was specified by the user
-         - arg_name: The name of the unsupported argument (string)
-         - extra_info: Extra information to include in the warning/error message (string)
-         - raise_error: If False (the default), raise a warning. If true, raise an exception
-                        (which interrupts the code).
+
+        Implementation note: This should be called in the "init" method of the
+        implementing class for each unsupported argument. For example, for the
+        'density_scale' argument of Species:
+            self._check_unsupported_argument(
+                'density_scale',
+                extra_info='My code can not handle a density_scale')
+
+        - arg_name: The name of the unsupported argument (string)
+        - extra_info: Extra information to include in the warning/error message (string)
+        - raise_error: If False (the default), raise a warning. If true, raise an exception
+                       (which interrupts the code).
         """
-        # --- Implementation note: This should be called in the "init" method of the implementing
-        # --- class for each unsupported argument. For example, for the 'density_scale' argument of Species:
-        # ---     self._check_unsupported_argument('density_scale', extra_info='My code can not handle a density_scale')
 
         # This compares the value of the parameter with the dault value in the __init__ method.
         # If they differ, this means that the user supplied a value, so a warning or error is raised.


### PR DESCRIPTION
This is a proposal for a mechanism to handle unsupported arguments and values.

For unsupported arguments, this checks the values of parameters against the default value - if they differ, this means that the user specified a value. A warning or error will be raised in this case.

Note that this replaces PR #61 (which had unrelated commits in it).

Implements #57