### PR TITLE
Added test of type checking and autoargs

### DIFF
--- a/PICMI_Python/applied_fields.py
+++ b/PICMI_Python/applied_fields.py
@@ -2,14 +2,20 @@
 These should be the base classes for Python implementation of the PICMI standard
 """
 import re
+import typing
+from collections.abc import Sequence
 
-from .base import _ClassWithInit
+from autoclass import autoargs
+from typeguard import typechecked
+
+from .base import _ClassWithInit, VectorFloat3
 
 # ---------------
 # Applied fields
 # ---------------
 
 
+@typechecked
 class PICMI_ConstantAppliedField(_ClassWithInit):
     """
     Describes a constant applied field
@@ -22,19 +28,16 @@ class PICMI_ConstantAppliedField(_ClassWithInit):
       - lower_bound=[None,None,None]: Lower bound of the region where the field is applied (vector) [m]
       - upper_bound=[None,None,None]: Upper bound of the region where the field is applied (vector) [m]
     """
-    def __init__(self, Ex=None, Ey=None, Ez=None, Bx=None, By=None, Bz=None,
-                 lower_bound=[None,None,None], upper_bound=[None,None,None],
-                 **kw):
-
-        self.Ex = Ex
-        self.Ey = Ey
-        self.Ez = Ez
-        self.Bx = Bx
-        self.By = By
-        self.Bz = Bz
-
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+    @autoargs(exclude=['kw'])
+    def __init__(self, Ex : float = None,
+                       Ey : float = None,
+                       Ez : float = None,
+                       Bx : float = None,
+                       By : float = None,
+                       Bz : float = None,
+                       lower_bound : VectorFloat3 = [None,None,None],
+                       upper_bound : VectorFloat3 = [None,None,None],
+                       **kw):
 
         self.handle_init(kw)
 

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -2,6 +2,9 @@
 """
 import inspect
 import warnings
+import typing
+from collections.abc import Sequence
+
 
 codename = None
 
@@ -26,8 +29,18 @@ def register_constants(implementation_constants):
 def _get_constants():
     return _implementation_constants
 
+VectorFloat3 = typing.NewType('VectorFloat3', Sequence[float])
+VectorInt3 = typing.NewType('VectorFloat3', Sequence[int])
+
 class _ClassWithInit(object):
+    def _check_vector_lengths(self):
+        for arg_name, arg_type in self.__init__.__annotations__.items():
+            if arg_type in [VectorFloat3, VectorInt3]:
+                assert len(getattr(self, arg_name)) == 3, Exception(f'{arg_name} must have a length of 3')
+
     def handle_init(self, kw):
+        self._check_vector_lengths()
+
         # --- Grab all keywords for the current code.
         # --- Arguments for other supported codes are ignored.
         # --- If there is anything left over, it is an error.

--- a/PICMI_Python/requirements.txt
+++ b/PICMI_Python/requirements.txt
@@ -1,2 +1,4 @@
 numpy~=1.15
 scipy~=1.5
+autoclass
+typeguard


### PR DESCRIPTION
This is an alternative proposal to what PR #63 is doing. This set of changes is much smaller but still does all of the things desired.

- [x] Reduce the number of times parameters are referenced
- [x] Runtime type checking on scalars and vectors
- [x] Checks lengths of scalars
- [x] Handles keyword arguments as before (allowing `codename_arg` with checking)
- [x] Fully backwards compatible (and allows class to be updated one by one)
- [x] Allows argument value checking in the `__init__` routine or separate callable method

Units tests need to be added, but there isn't much to test since it is using commonly used packages.
Documentation can be added (much of that from PR #63 can be carried over).