### PR TITLE
Add class for field ionization

### DIFF
--- a/Examples/laser_acceleration/laser_acceleration_PICMI.py
+++ b/Examples/laser_acceleration/laser_acceleration_PICMI.py
@@ -103,9 +103,10 @@ plasma = picmi.MultiSpecies(
 # Set the ionization for the species number 1 (Argon)
 # and place the created electrons into the species number 2 (electron)
 if picmi.codename != 'warpx':
-    plasma['Argon'].activate_field_ionization(
-        model           = "ADK", # Ammosov-Delone-Krainov model
-        product_species = plasma['e-'])
+    argon_ionization = picmi.FieldIonization(
+                model           = "ADK", # Ammosov-Delone-Krainov model
+                ionized_species = plasma['Argon'],
+                product_species = plasma['e-'])
 
 # --- electron bunch
 beam_dist = picmi.GaussianBunchDistribution(
@@ -190,6 +191,9 @@ if picmi.codename == 'warpx':
     initialize_self_field = False
 sim.add_species(species=beam, layout=beam_layout,
                 initialize_self_field=initialize_self_field)
+
+if picmi.codename != 'warpx':
+    sim.add_interaction(argon_ionization)
 
 # Add the diagnostics
 sim.add_diagnostic(field_diag)

--- a/PICMI_Python/__init__.py
+++ b/PICMI_Python/__init__.py
@@ -2,6 +2,7 @@ from .base import *
 from .diagnostics import *
 from .fields import *
 from .applied_fields import *
+from .interactions import *
 from .lasers import *
 from .particles import *
 from .simulation import *

--- a/PICMI_Python/interactions.py
+++ b/PICMI_Python/interactions.py
@@ -1,0 +1,21 @@
+"""Classes following the PICMI standard
+These should be the base classes for Python implementation of the PICMI standard
+The classes in this file are related to interactions (e.g. field ionization, collisions, QED)
+"""
+
+from .base import _ClassWithInit
+
+class PICMI_FieldIonization(_ClassWithInit):
+    """
+    Field ionization on an ion species
+    - model: ionization model, e.g. "ADK" (string)
+    - ionized_species: Species that is ionized
+    - product_species: Species in which ionized electrons are stored.
+    """
+    def __init__(self, model, ionized_species, product_species, **kw):
+        self.model = model
+        self.ionized_species = ionized_species
+        self.product_species = product_species
+
+        self.handle_init(kw)
+

--- a/PICMI_Python/interactions.py
+++ b/PICMI_Python/interactions.py
@@ -8,9 +8,17 @@ from .base import _ClassWithInit
 class PICMI_FieldIonization(_ClassWithInit):
     """
     Field ionization on an ion species
-    - model: ionization model, e.g. "ADK" (string)
-    - ionized_species: Species that is ionized
-    - product_species: Species in which ionized electrons are stored.
+
+    Parameters
+    ----------
+    model: string
+        Ionization model, e.g. "ADK"
+
+    ionized_species: species instance
+        Species that is ionized
+
+    product_species: species instance
+        Species in which ionized electrons are stored.
     """
     def __init__(self, model, ionized_species, product_species, **kw):
         self.model = model

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -53,10 +53,7 @@ class PICMI_Species(_ClassWithInit):
         self.handle_init(kw)
 
     def activate_field_ionization(self, model, product_species):
-        # --- TODO: One way of handling interactions is to add a class for each type
-        # ---       of interaction. Instances would be added to the interactions list
-        # ---       instead of the list of parameters.
-        self.interactions.append(['ionization', model, product_species])
+        self.interactions.append(PICMI_FieldIonization(model, product_species))
 
 
 class PICMI_MultiSpecies(_ClassWithInit):
@@ -387,5 +384,18 @@ class PICMI_PseudoRandomLayout(_ClassWithInit):
         self.n_macroparticles_per_cell = n_macroparticles_per_cell
         self.seed = seed
         self.grid = grid
+
+        self.handle_init(kw)
+        
+        
+class PICMI_FieldIonization(_ClassWithInit):
+    """
+    Field ionization on an ion species
+    - model: ionization model, e.g. "ADK" (string)
+    - product_species: Species in which ionized electrons are stored.
+    """
+    def __init__(self, model, product_species, **kw):
+        self.model = model
+        self.product_species = product_species
 
         self.handle_init(kw)

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -52,9 +52,6 @@ class PICMI_Species(_ClassWithInit):
 
         self.handle_init(kw)
 
-    def activate_field_ionization(self, model, product_species):
-        self.interactions.append(PICMI_FieldIonization(model, product_species))
-
 
 class PICMI_MultiSpecies(_ClassWithInit):
     """
@@ -384,18 +381,5 @@ class PICMI_PseudoRandomLayout(_ClassWithInit):
         self.n_macroparticles_per_cell = n_macroparticles_per_cell
         self.seed = seed
         self.grid = grid
-
-        self.handle_init(kw)
-        
-        
-class PICMI_FieldIonization(_ClassWithInit):
-    """
-    Field ionization on an ion species
-    - model: ionization model, e.g. "ADK" (string)
-    - product_species: Species in which ionized electrons are stored.
-    """
-    def __init__(self, model, product_species, **kw):
-        self.model = model
-        self.product_species = product_species
 
         self.handle_init(kw)

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -71,6 +71,8 @@ class PICMI_Simulation(_ClassWithInit):
 
         self.diagnostics = []
 
+        self.interactions = []
+
         self.cpu_split = cpu_split
         self.load_balancing = load_balancing
 
@@ -163,6 +165,14 @@ class PICMI_Simulation(_ClassWithInit):
                 One of the diagnostic objects.
         """
         self.diagnostics.append(diagnostic)
+
+    def add_interaction(self, interaction):
+        """
+        Add an interaction
+          - interaction: object
+                One of the interaction objects.
+        """
+        self.interactions.append(interaction)
 
     def set_max_step(self, max_steps):
         """

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -182,8 +182,11 @@ class PICMI_Simulation(_ClassWithInit):
     def add_interaction(self, interaction):
         """
         Add an interaction
-          - interaction: object
-                One of the interaction objects.
+
+        Parameters
+        ----------
+        interaction: interaction instance
+            One of the interaction objects.
         """
         self.interactions.append(interaction)
 


### PR DESCRIPTION
We had talked about adding classes for different types of particle interactions. Is this typically what you had in mind @dpgrote?

In any case, we probably should not merge this PR until we have updated this feature in WarpX (and possibly other codes that use picmi).
By the way, how much do we care about backward compatibility? Should we do something about it in this PR?