### PR TITLE
Docs: Grid 1D

### DIFF
--- a/Docs/source/standard/grid.rst
+++ b/Docs/source/standard/grid.rst
@@ -15,6 +15,11 @@ Grids
 
 .. autoclass:: picmistandard.PICMI_Cartesian2DGrid
 
+1D Cartesian geometry
+---------------------
+
+.. autoclass:: picmistandard.PICMI_Cartesian1DGrid
+
 Cylindrical geometry
 --------------------
 


### PR DESCRIPTION
Add the missing doc link for `picmistandard.PICMI_Cartesian1DGrid`.

Follow-up to #50