### PR TITLE
Reformatting doc strings to a common standard

### DIFF
--- a/PICMI_Python/applied_fields.py
+++ b/PICMI_Python/applied_fields.py
@@ -16,31 +16,29 @@ class PICMI_ConstantAppliedField(_ClassWithInit):
 
     Parameters
     ----------
-    - Ex: float
-          Constant Ex field [V/m]
+    Ex: float, default=0.
+        Constant Ex field [V/m]
 
-    - Ey: float
-          Constant Ey field [V/m]
+    Ey: float, default=0.
+        Constant Ey field [V/m]
 
-    - Ez: float
-          Constant Ez field [V/m]
+    Ez: float, default=0.
+        Constant Ez field [V/m]
 
-    - Bx: float
-          Constant Bx field [T]
+    Bx: float, default=0.
+        Constant Bx field [T]
 
-    - By: float
-          Constant By field [T]
+    By: float, default=0.
+        Constant By field [T]
 
-    - Bz: float
+    Bz: float, default=0.
         Constant Bz field [T]
 
-    - lower_bound: vector
+    lower_bound: vector, optional
         Lower bound of the region where the field is applied [m].
-        (default = [None,None,None])
 
-    - upper_bound: vector
+    upper_bound: vector, optional
         Upper bound of the region where the field is applied [m]
-        (default = [None,None,None])
     """
     def __init__(self, Ex=None, Ey=None, Ez=None, Bx=None, By=None, Bz=None,
                  lower_bound=[None,None,None], upper_bound=[None,None,None],
@@ -69,31 +67,29 @@ class PICMI_AnalyticAppliedField(_ClassWithInit):
 
     Parameters
     ----------
-    - Ex_expression: string
-          Analytic expression describing Ex field [V/m]
+    Ex_expression: string, optional
+        Analytic expression describing Ex field [V/m]
 
-    - Ey_expression: string
-          Analytic expression describing Ey field [V/m]
+    Ey_expression: string, optional
+        Analytic expression describing Ey field [V/m]
 
-    - Ez_expression: string
-          Analytic expression describing Ez field [V/m]
+    Ez_expression: string, optional
+        Analytic expression describing Ez field [V/m]
 
-    - Bx_expression: string
-          Analytic expression describing Bx field [T]
+    Bx_expression: string, optional
+        Analytic expression describing Bx field [T]
 
-    - By_expression: string
-          Analytic expression describing By field [T]
+    By_expression: string, optional
+        Analytic expression describing By field [T]
 
-    - Bz_expression: string
-          Analytic expression describing Bz field [T]
+    Bz_expression: string, optional
+        Analytic expression describing Bz field [T]
 
-    - lower_bound: vector
+    lower_bound: vector, optional
         Lower bound of the region where the field is applied [m].
-        (default = [None,None,None])
 
-    - upper_bound: vector
+    upper_bound: vector, optional
         Upper bound of the region where the field is applied [m]
-        (default = [None,None,None])
     """
     def __init__(self, Ex_expression=None, Ey_expression=None, Ez_expression=None,
                        Bx_expression=None, By_expression=None, Bz_expression=None,
@@ -135,20 +131,20 @@ class PICMI_Mirror(_ClassWithInit):
 
     Parameters
     ----------
-    - x_front_location: float
-          Location in x of the front of the nirror [m]
+    x_front_location: float, optional (see comment below)
+        Location in x of the front of the nirror [m]
 
-    - y_front_location: float
-          Location in y of the front of the nirror [m]
+    y_front_location: float, optional (see comment below)
+        Location in y of the front of the nirror [m]
 
-    - z_front_location: float
-          Location in z of the front of the nirror [m]
+    z_front_location: float, optional (see comment below)
+        Location in z of the front of the nirror [m]
 
-    - depth: float
-          Depth of the mirror [m]
+    depth: float, optional (see comment below)
+        Depth of the mirror [m]
 
-    - number_of_cells: integer
-          Minimum numer of cells zeroed out
+    number_of_cells: integer, optional (see comment below)
+        Minimum numer of cells zeroed out
 
     Only one of the [x,y,z]_front_location should be specified. The mirror will be set
     perpendicular to the respective direction and infinite in the others.

--- a/PICMI_Python/applied_fields.py
+++ b/PICMI_Python/applied_fields.py
@@ -13,14 +13,34 @@ from .base import _ClassWithInit
 class PICMI_ConstantAppliedField(_ClassWithInit):
     """
     Describes a constant applied field
-      - Ex: Constant Ex field (float) [V/m]
-      - Ey: Constant Ey field (float) [V/m]
-      - Ez: Constant Ez field (float) [V/m]
-      - Bx: Constant Bx field (float) [T]
-      - By: Constant By field (float) [T]
-      - Bz: Constant Bz field (float) [T]
-      - lower_bound=[None,None,None]: Lower bound of the region where the field is applied (vector) [m]
-      - upper_bound=[None,None,None]: Upper bound of the region where the field is applied (vector) [m]
+
+    Parameters
+    ----------
+    - Ex: float
+          Constant Ex field [V/m]
+
+    - Ey: float
+          Constant Ey field [V/m]
+
+    - Ez: float
+          Constant Ez field [V/m]
+
+    - Bx: float
+          Constant Bx field [T]
+
+    - By: float
+          Constant By field [T]
+
+    - Bz: float
+        Constant Bz field [T]
+
+    - lower_bound: vector
+        Lower bound of the region where the field is applied [m].
+        (default = [None,None,None])
+
+    - upper_bound: vector
+        Upper bound of the region where the field is applied [m]
+        (default = [None,None,None])
     """
     def __init__(self, Ex=None, Ey=None, Ez=None, Bx=None, By=None, Bz=None,
                  lower_bound=[None,None,None], upper_bound=[None,None,None],
@@ -42,17 +62,38 @@ class PICMI_ConstantAppliedField(_ClassWithInit):
 class PICMI_AnalyticAppliedField(_ClassWithInit):
     """
     Describes an analytic applied field
-      - Ex_expression: Analytic expression describing Ex field (string) [V/m]
-      - Ey_expression: Analytic expression describing Ey field (string) [V/m]
-      - Ez_expression: Analytic expression describing Ez field (string) [V/m]
-      - Bx_expression: Analytic expression describing Bx field (string) [T]
-      - By_expression: Analytic expression describing By field (string) [T]
-      - Bz_expression: Analytic expression describing Bz field (string) [T]
-               Expressions should be in terms of the position and time, written as 'x', 'y', 'z', 't'.
-               Parameters can be used in the expression with the values given as additional keyword arguments.
-               Expressions should be relative to the lab frame.
-      - lower_bound=[None,None,None]: Lower bound of the region where the field is applied (vector) [m]
-      - upper_bound=[None,None,None]: Upper bound of the region where the field is applied (vector) [m]
+
+    The expressions should be in terms of the position and time, written as 'x', 'y', 'z', 't'.
+    Parameters can be used in the expression with the values given as additional keyword arguments.
+    Expressions should be relative to the lab frame.
+
+    Parameters
+    ----------
+    - Ex_expression: string
+          Analytic expression describing Ex field [V/m]
+
+    - Ey_expression: string
+          Analytic expression describing Ey field [V/m]
+
+    - Ez_expression: string
+          Analytic expression describing Ez field [V/m]
+
+    - Bx_expression: string
+          Analytic expression describing Bx field [T]
+
+    - By_expression: string
+          Analytic expression describing By field [T]
+
+    - Bz_expression: string
+          Analytic expression describing Bz field [T]
+
+    - lower_bound: vector
+        Lower bound of the region where the field is applied [m].
+        (default = [None,None,None])
+
+    - upper_bound: vector
+        Upper bound of the region where the field is applied [m]
+        (default = [None,None,None])
     """
     def __init__(self, Ex_expression=None, Ey_expression=None, Ez_expression=None,
                        Bx_expression=None, By_expression=None, Bz_expression=None,
@@ -91,11 +132,23 @@ class PICMI_Mirror(_ClassWithInit):
     """
     Describes a perfectly reflecting mirror, where the E and B fields are zeroed
     out in a plane of finite thickness.
-      - x_front_location: Location in x of the front of the nirror (float) [m]
-      - y_front_location: Location in y of the front of the nirror (float) [m]
-      - z_front_location: Location in z of the front of the nirror (float) [m]
-      - depth: Depth of the mirror (float) [m]
-      - number_of_cells: Minimum numer of cells zeroed out (integer)
+
+    Parameters
+    ----------
+    - x_front_location: float
+          Location in x of the front of the nirror [m]
+
+    - y_front_location: float
+          Location in y of the front of the nirror [m]
+
+    - z_front_location: float
+          Location in z of the front of the nirror [m]
+
+    - depth: float
+          Depth of the mirror [m]
+
+    - number_of_cells: integer
+          Minimum numer of cells zeroed out
 
     Only one of the [x,y,z]_front_location should be specified. The mirror will be set
     perpendicular to the respective direction and infinite in the others.

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -19,7 +19,13 @@ def register_codename(_codename):
 _implementation_constants = None
 
 def register_constants(implementation_constants):
-    """This must be called by the implementing code, passing in the constans object"""
+    """This must be called by the implementing code, passing in the constans object
+
+    Parameters
+    ----------
+    - implementation_constants: python object
+        The object must have as attributes the physical constants
+    """
     global _implementation_constants
     _implementation_constants = implementation_constants
 
@@ -56,10 +62,18 @@ class _ClassWithInit(object):
 
     def _check_unsupported_argument(self, arg_name, message=None, raise_error=False):
         """Raise a warning or exception if an unsupported argument was specified by the user
-        - arg_name: The name of the unsupported argument (string)
-        - message: Information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
+
+        Parameters
+        ----------
+        - arg_name: string
+            The name of the unsupported argument
+
+        - message: string
+            Information to include in the warning/error message
+
+        - raise_error: bool
+            If False (the default), raise a warning. If true, raise an exception
+            (which interrupts the code).
 
         Implementation note: This should be called in the "init" method of the
         implementing class for each unsupported argument. For example, for the
@@ -86,10 +100,18 @@ class _ClassWithInit(object):
 
     def _unsupported_value(self, arg_name, message='', raise_error=True):
         """Raise a warning or exception for argument with an unsupported value.
-        - arg_name: The name of the argument with an unsupported value (string)
-        - message: Information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
+
+        Parameters
+        ----------
+        - arg_name: string
+            The name of the argument with an unsupported value
+
+        - message: string
+            Information to include in the warning/error message
+
+        - raise_error: bool
+            If False (the default), raise a warning. If true, raise an exception
+            (which interrupts the code).
 
         Implementation note: This should be called when the implementing code handles
         the input arguments. For example, for 'method' in Species:
@@ -110,10 +132,18 @@ class _ClassWithInit(object):
 
     def _check_deprecated_argument(self, arg_name, message=None, raise_error=False):
         """Raise a warning or exception if a deprecated argument was specified by the user
-        - arg_name: The name of the deprecated argument (string)
-        - message: Information to include in the warning/error message (string)
-        - raise_error: If False (the default), raise a warning. If true, raise an exception
-                       (which interrupts the code).
+
+        Parameters
+        ----------
+        - arg_name: string
+            The name of the deprecated argument
+
+        - message: string
+            Information to include in the warning/error message
+
+        - raise_error: bool
+            If False (the default), raise a warning. If true, raise an exception
+            (which interrupts the code).
 
         Implementation note: This should be called within PICMI in the "__init__" method of classes
         for each deprecated argument. This assumes that the argument is still included in the

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -23,7 +23,7 @@ def register_constants(implementation_constants):
 
     Parameters
     ----------
-    - implementation_constants: python object
+    implementation_constants: python object
         The object must have as attributes the physical constants
     """
     global _implementation_constants
@@ -65,13 +65,13 @@ class _ClassWithInit(object):
 
         Parameters
         ----------
-        - arg_name: string
+        arg_name: string
             The name of the unsupported argument
 
-        - message: string
+        message: string
             Information to include in the warning/error message
 
-        - raise_error: bool
+        raise_error: bool
             If False (the default), raise a warning. If true, raise an exception
             (which interrupts the code).
 
@@ -103,13 +103,13 @@ class _ClassWithInit(object):
 
         Parameters
         ----------
-        - arg_name: string
+        arg_name: string
             The name of the argument with an unsupported value
 
-        - message: string
+        message: string
             Information to include in the warning/error message
 
-        - raise_error: bool
+        raise_error: bool
             If False (the default), raise a warning. If true, raise an exception
             (which interrupts the code).
 
@@ -135,13 +135,13 @@ class _ClassWithInit(object):
 
         Parameters
         ----------
-        - arg_name: string
+        arg_name: string
             The name of the deprecated argument
 
-        - message: string
+        message: string
             Information to include in the warning/error message
 
-        - raise_error: bool
+        raise_error: bool
             If False (the default), raise a warning. If true, raise an exception
             (which interrupts the code).
 

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -13,24 +13,47 @@ from .base import _ClassWithInit
 class PICMI_FieldDiagnostic(_ClassWithInit):
     """
     Defines the electromagnetic field diagnostics in the simulation frame
-      - grid: Grid object for the diagnostic
-      - period: Period of time steps that the diagnostic is performed
-      - data_list=None: List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
-                        Defaults to the output list of the implementing code.
-      - write_dir='.': Directory where data is to be written
-      - step_min=None: Minimum step at which diagnostics could be written (optional)
-                       Defaults to step 0.
-      - step_max=None: Maximum step at which diagnostics could be written (optional)
-                       Defaults to no limit.
-      - number_of_cells=None: Number of cells in each dimension (optional)
-                              If not given, will be obtained from grid.
-      - lower_bound=None: Lower corner of diagnostics box in each direction (optional)
-                          If not given, will be obtained from grid.
-      - upper_bound=None: Higher corner of diagnostics box in each direction (optional)
-                          If not given, will be obtained from grid.
-      - parallelio=None: If set to True, field diagnostics are dumped in parallel (optional)
-      - name: Sets the base name for the diagnostic output files (optional)
 
+    Parameters
+    ----------
+    - grid: grid instance
+        Grid object for the diagnostic
+
+    - period: integer
+        Period of time steps that the diagnostic is performed
+
+    - data_list: list of strings (optional)
+        List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
+        Defaults to the output list of the implementing code.
+
+    - write_dir: string (optional)
+        Directory where data is to be written
+
+    - step_min: integer (optional)
+        Minimum step at which diagnostics could be written.
+        Defaults to step 0.
+
+    - step_max: integer (optional)
+        Maximum step at which diagnostics could be written.
+        Defaults to no limit.
+
+    - number_of_cells: vector of integers (optional)
+        Number of cells in each dimension.
+        If not given, will be obtained from grid.
+
+    - lower_bound: vector of reals (optional)
+        Lower corner of diagnostics box in each direction.
+        If not given, will be obtained from grid.
+
+    - upper_bound: vector of reals (optional)
+        Higher corner of diagnostics box in each direction.
+        If not given, will be obtained from grid.
+
+    - parallelio: bool (optional)
+        If set to True, field diagnostics are dumped in parallel
+
+    - name: string (optional)
+        Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, period, data_list=None,
                  write_dir = None,
@@ -64,23 +87,47 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
 class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
     """
     Defines the electrostatic field diagnostics in the simulation frame
-      - grid: Grid object for the diagnostic
-      - period: Period of time steps that the diagnostic is performed
-      - data_list=None: List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc.
-                        Defaults to the output list of the implementing code.
-      - write_dir='.': Directory where data is to be written
-      - step_min=None: Minimum step at which diagnostics could be written (optional)
-                       Defaults to step 0.
-      - step_max=None: Maximum step at which diagnostics could be written (optional)
-                       Defaults to no limit.
-      - number_of_cells=None: Number of cells in each dimension (optional)
-                              If not given, will be obtained from grid.
-      - lower_bound=None: Lower corner of diagnostics box in each direction (optional)
-                          If not given, will be obtained from grid.
-      - upper_bound=None: Higher corner of diagnostics box in each direction (optional)
-                          If not given, will be obtained from grid.
-      - parallelio=None: If set to True, field diagnostics are dumped in parallel (optional)
-      - name: Sets the base name for the diagnostic output files (optional)
+
+    Parameters
+    ----------
+    - grid: grid instance
+        Grid object for the diagnostic
+
+    - period: integer
+        Period of time steps that the diagnostic is performed
+
+    - data_list: list of strings (optional)
+        List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc.
+        Defaults to the output list of the implementing code.
+
+    - write_dir: string (optional)
+        Directory where data is to be written
+
+    - step_min: integer (optional)
+        Minimum step at which diagnostics could be written.
+        Defaults to step 0.
+
+    - step_max: integer (optional)
+        Maximum step at which diagnostics could be written.
+        Defaults to no limit.
+
+    - number_of_cells: vector of integers (optional)
+        Number of cells in each dimension.
+        If not given, will be obtained from grid.
+
+    - lower_bound: vector of reals (optional)
+        Lower corner of diagnostics box in each direction.
+        If not given, will be obtained from grid.
+
+    - upper_bound: vector of reals (optional)
+        Higher corner of diagnostics box in each direction.
+        If not given, will be obtained from grid.
+
+    - parallelio: bool (optional)
+        If set to True, field diagnostics are dumped in parallel
+
+    - name: string (optional)
+        Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, period, data_list=None,
                  write_dir = None,
@@ -114,18 +161,36 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
 class PICMI_ParticleDiagnostic(_ClassWithInit) :
     """
     Defines the particle diagnostics in the simulation frame
-      - period: Period of time steps that the diagnostic is performed
-      - species: Species or list of species to write out
-                 Note that the name attribute must be defined for the species.
-      - data_list=None: The data to be written out. Possible values 'position', 'momentum', 'weighting'.
-                        Defaults to the output list of the implementing code.
-      - write_dir='.': Directory where data is to be written
-      - step_min=None: Minimum step at which diagnostics could be written (optional)
-                       Defaults to step 0.
-      - step_max=None: Maximum step at which diagnostics could be written (optional)
-                       Defaults to no limit.
-      - parallelio=None: If set to True, particle diagnostics are dumped in parallel (optional)
-      - name: Sets the base name for the diagnostic output files (optional)
+
+    Parameters
+    ----------
+    - period: integer
+        Period of time steps that the diagnostic is performed
+
+    - species: species instance or list of species instances
+        Species to write out.
+        Note that the name attribute must be defined for the species.
+
+    - data_list: list of strings (optional)
+        The data to be written out. Possible values 'position', 'momentum', 'weighting'.
+        Defaults to the output list of the implementing code.
+
+    - write_dir: string (optional)
+        Directory where data is to be written
+
+    - step_min: integer (optional)
+        Minimum step at which diagnostics could be written.
+        Defaults to step 0.
+
+    - step_max: integer (optional)
+        Maximum step at which diagnostics could be written.
+        Defaults to no limit.
+
+    - parallelio: bool (optional)
+        If set to True, particle diagnostics are dumped in parallel
+
+    - name: string (optional)
+        Sets the base name for the diagnostic output files
     """
 
     def __init__(self, period, species, data_list=None,
@@ -159,16 +224,38 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
 class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
     """
     Defines the electromagnetic field diagnostics in the lab frame
-      - grid: Grid object for the diagnostic
-      - num_snapshots: Number of lab frame snapshots to make
-      - dt_snapshots: Time between each snapshot in lab frame
-      - data_list=None: List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
-                        Defaults to the output list of the implementing code.
-      - z_subsampling=1: A factor which is applied on the resolution of the lab frame reconstruction. (integer)
-      - time_start=0.: Time for the first snapshot in lab frame
-      - write_dir='.': Directory where data is to be written
-      - parallelio=None: If set to True, field diagnostics are dumped in parallel (optional)
-      - name: Sets the base name for the diagnostic output files (optional)
+
+    Parameters
+    ----------
+    - grid: grid instance
+        Grid object for the diagnostic
+
+    - num_snapshots: integer
+        Number of lab frame snapshots to make
+
+    - dt_snapshots: real
+        Time between each snapshot in lab frame
+
+    - data_list: list of strings (optional)
+        List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
+        Defaults to the output list of the implementing code.
+
+    - z_subsampling: integer (optional)
+        A factor which is applied on the resolution of the lab frame reconstruction.
+        Defaults to 1.
+
+    - time_start: real (optional)
+        Time for the first snapshot in lab frame.
+        Defaults to 0.
+
+    - write_dir: string (optional)
+        Directory where data is to be written
+
+    - parallelio: bool (optional)
+        If set to True, field diagnostics are dumped in parallel
+
+    - name: string (optional)
+        Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,
                  z_subsampling = 1, time_start = 0.,
@@ -196,17 +283,38 @@ class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
 class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
     """
     Defines the particle diagnostics in the lab frame
-      - grid: Grid object for the diagnostic
-      - num_snapshots: Number of lab frame snapshots to make
-      - dt_snapshots: Time between each snapshot in lab frame
-      - data_list=None: The data to be written out. Possible values 'position', 'momentum', 'weighting'.
-                        Defaults to the output list of the implementing code.
-      - time_start=0.: Time for the first snapshot in lab frame
-      - species: Species or list of species to write out
-                 Note that the name attribute must be defined for the species.
-      - write_dir='.': Directory where data is to be written
-      - parallelio=None: If set to True, particle diagnostics are dumped in parallel (optional)
-      - name: Sets the base name for the diagnostic output files (optional)
+
+    Parameters
+    ----------
+    - grid: grid instance
+        Grid object for the diagnostic
+
+    - num_snapshots: integer
+        Number of lab frame snapshots to make
+
+    - dt_snapshots: real
+        Time between each snapshot in lab frame
+
+    - species: species instance or list of species instances
+        Species to write out.
+        Note that the name attribute must be defined for the species.
+
+    - data_list: list of strings (optional)
+        The data to be written out. Possible values 'position', 'momentum', 'weighting'.
+        Defaults to the output list of the implementing code.
+
+    - time_start: real (optional)
+        Time for the first snapshot in lab frame.
+        Defaults to 0.
+
+    - write_dir: string (optional)
+        Directory where data is to be written
+
+    - parallelio: bool (optional)
+        If set to True, particle diagnostics are dumped in parallel
+
+    - name: string (optional)
+        Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,
                  time_start = 0.,

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -16,43 +16,41 @@ class PICMI_FieldDiagnostic(_ClassWithInit):
 
     Parameters
     ----------
-    - grid: grid instance
+    grid: grid instance
         Grid object for the diagnostic
 
-    - period: integer
+    period: integer
         Period of time steps that the diagnostic is performed
 
-    - data_list: list of strings (optional)
+    data_list: list of strings, optional
         List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
         Defaults to the output list of the implementing code.
 
-    - write_dir: string (optional)
+    write_dir: string, optional
         Directory where data is to be written
 
-    - step_min: integer (optional)
-        Minimum step at which diagnostics could be written.
-        Defaults to step 0.
+    step_min: integer, default=0
+        Minimum step at which diagnostics could be written
 
-    - step_max: integer (optional)
-        Maximum step at which diagnostics could be written.
-        Defaults to no limit.
+    step_max: integer, default=unbounded
+        Maximum step at which diagnostics could be written
 
-    - number_of_cells: vector of integers (optional)
+    number_of_cells: vector of integers, optional
         Number of cells in each dimension.
         If not given, will be obtained from grid.
 
-    - lower_bound: vector of reals (optional)
+    lower_bound: vector of floats, optional
         Lower corner of diagnostics box in each direction.
         If not given, will be obtained from grid.
 
-    - upper_bound: vector of reals (optional)
+    upper_bound: vector of floats, optional
         Higher corner of diagnostics box in each direction.
         If not given, will be obtained from grid.
 
-    - parallelio: bool (optional)
+    parallelio: bool, optional
         If set to True, field diagnostics are dumped in parallel
 
-    - name: string (optional)
+    name: string, optional
         Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, period, data_list=None,
@@ -90,43 +88,41 @@ class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
 
     Parameters
     ----------
-    - grid: grid instance
+    grid: grid instance
         Grid object for the diagnostic
 
-    - period: integer
+    period: integer
         Period of time steps that the diagnostic is performed
 
-    - data_list: list of strings (optional)
+    data_list: list of strings, optional
         List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc.
         Defaults to the output list of the implementing code.
 
-    - write_dir: string (optional)
+    write_dir: string, optional
         Directory where data is to be written
 
-    - step_min: integer (optional)
-        Minimum step at which diagnostics could be written.
-        Defaults to step 0.
+    step_min: integer, default=0
+        Minimum step at which diagnostics could be written
 
-    - step_max: integer (optional)
-        Maximum step at which diagnostics could be written.
-        Defaults to no limit.
+    step_max: integer, default=unbounded
+        Maximum step at which diagnostics could be written
 
-    - number_of_cells: vector of integers (optional)
+    number_of_cells: vector of integers, optional
         Number of cells in each dimension.
         If not given, will be obtained from grid.
 
-    - lower_bound: vector of reals (optional)
+    lower_bound: vector of floats, optional
         Lower corner of diagnostics box in each direction.
         If not given, will be obtained from grid.
 
-    - upper_bound: vector of reals (optional)
+    upper_bound: vector of floats, optional
         Higher corner of diagnostics box in each direction.
         If not given, will be obtained from grid.
 
-    - parallelio: bool (optional)
+    parallelio: bool, optional
         If set to True, field diagnostics are dumped in parallel
 
-    - name: string (optional)
+    name: string, optional
         Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, period, data_list=None,
@@ -164,32 +160,30 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
 
     Parameters
     ----------
-    - period: integer
+    period: integer
         Period of time steps that the diagnostic is performed
 
-    - species: species instance or list of species instances
+    species: species instance or list of species instances
         Species to write out.
         Note that the name attribute must be defined for the species.
 
-    - data_list: list of strings (optional)
+    data_list: list of strings, optional
         The data to be written out. Possible values 'position', 'momentum', 'weighting'.
         Defaults to the output list of the implementing code.
 
-    - write_dir: string (optional)
+    write_dir: string, optional
         Directory where data is to be written
 
-    - step_min: integer (optional)
-        Minimum step at which diagnostics could be written.
-        Defaults to step 0.
+    step_min: integer, default=0
+        Minimum step at which diagnostics could be written
 
-    - step_max: integer (optional)
-        Maximum step at which diagnostics could be written.
-        Defaults to no limit.
+    step_max: integer, default=unbounded
+        Maximum step at which diagnostics could be written
 
-    - parallelio: bool (optional)
+    parallelio: bool, optional
         If set to True, particle diagnostics are dumped in parallel
 
-    - name: string (optional)
+    name: string, optional
         Sets the base name for the diagnostic output files
     """
 
@@ -227,34 +221,32 @@ class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
 
     Parameters
     ----------
-    - grid: grid instance
+    grid: grid instance
         Grid object for the diagnostic
 
-    - num_snapshots: integer
+    num_snapshots: integer
         Number of lab frame snapshots to make
 
-    - dt_snapshots: real
+    dt_snapshots: float
         Time between each snapshot in lab frame
 
-    - data_list: list of strings (optional)
+    data_list: list of strings, optional
         List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
         Defaults to the output list of the implementing code.
 
-    - z_subsampling: integer (optional)
-        A factor which is applied on the resolution of the lab frame reconstruction.
-        Defaults to 1.
+    z_subsampling: integer, default=1
+        A factor which is applied on the resolution of the lab frame reconstruction
 
-    - time_start: real (optional)
-        Time for the first snapshot in lab frame.
-        Defaults to 0.
+    time_start: float, default=0
+        Time for the first snapshot in lab frame
 
-    - write_dir: string (optional)
+    write_dir: string, optional
         Directory where data is to be written
 
-    - parallelio: bool (optional)
+    parallelio: bool, optional
         If set to True, field diagnostics are dumped in parallel
 
-    - name: string (optional)
+    name: string, optional
         Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,
@@ -286,34 +278,33 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
 
     Parameters
     ----------
-    - grid: grid instance
+    grid: grid instance
         Grid object for the diagnostic
 
-    - num_snapshots: integer
+    num_snapshots: integer
         Number of lab frame snapshots to make
 
-    - dt_snapshots: real
+    dt_snapshots: float
         Time between each snapshot in lab frame
 
-    - species: species instance or list of species instances
+    species: species instance or list of species instances
         Species to write out.
         Note that the name attribute must be defined for the species.
 
-    - data_list: list of strings (optional)
+    data_list: list of strings, optional
         The data to be written out. Possible values 'position', 'momentum', 'weighting'.
         Defaults to the output list of the implementing code.
 
-    - time_start: real (optional)
-        Time for the first snapshot in lab frame.
-        Defaults to 0.
+    time_start: float, default=0
+        Time for the first snapshot in lab frame
 
-    - write_dir: string (optional)
+    write_dir: string, optional
         Directory where data is to be written
 
-    - parallelio: bool (optional)
+    parallelio: bool, optional
         If set to True, particle diagnostics are dumped in parallel
 
-    - name: string (optional)
+    name: string, optional
         Sets the base name for the diagnostic output files
     """
     def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,

--- a/PICMI_Python/fields.py
+++ b/PICMI_Python/fields.py
@@ -19,23 +19,23 @@ class PICMI_ElectromagneticSolver(_ClassWithInit):
     grid: grid instance
         Grid object for the diagnostic
 
-    method: string
-        One of 'Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', or 'ECT'
+    method: {'Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT'}
+        The advance method use to solve Maxwell's equations. The default method is code dependent.
 
-        'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
+        - 'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
 
-        'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties
+        - 'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties
           (https://doi.org/10.1103/PhysRevSTAB.16.041303)
 
-        'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
+        - 'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
 
-        'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
+        - 'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
 
-        'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
+        - 'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
 
-        'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
+        - 'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
 
-        'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
+        - 'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
 
     stencil_order: vector of integers
         Order of stencil for each axis (-1=infinite)

--- a/PICMI_Python/fields.py
+++ b/PICMI_Python/fields.py
@@ -13,27 +13,62 @@ from .base import _ClassWithInit
 class PICMI_ElectromagneticSolver(_ClassWithInit):
     """
     Electromagnetic field solver
-      - grid: grid object to be used by the solver (grid object)
-      - method: One of 'Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', or 'ECT' (string)
-        - 'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
-        - 'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties
+
+    Parameters
+    ----------
+    grid: grid instance
+        Grid object for the diagnostic
+
+    method: string
+        One of 'Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', or 'ECT'
+
+        'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
+
+        'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties
           (https://doi.org/10.1103/PhysRevSTAB.16.041303)
-        - 'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
-        - 'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
-        - 'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
-        - 'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
-        - 'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
-      - stencil_order: Order of stencil for each axis (-1=infinite) (vector of integers)
-      - cfl = None: Fraction of the Courant-Friedrich-Lewy criteria [1] (float)
-      - l_nodal = None: Quantities are at nodes if True, staggered otherwise (boolean)
-      - source_smoother = None: Smoother object to apply to the sources (smoother object)
-      - field_smoother = None: Smoother object to apply to the fields (smoother object)
-      - subcycling = None: level of subcycling for the GPSTD solver (integer)
-      - galilean_velocity = None: Velocity of Galilean reference frame (vector of floats) [m/s]
-      - divE_cleaning = None: Solver uses div(E) cleaning if True (boolean)
-      - divB_cleaning = None: Solver uses div(B) cleaning if True (boolean)
-      - pml_divE_cleaning = None: Solver uses div(E) cleaning in the PML if True (boolean)
-      - pml_divB_cleaning = None: Solver uses div(B) cleaning in the PML if True (boolean)
+
+        'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
+
+        'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
+
+        'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
+
+        'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
+
+        'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
+
+    stencil_order: vector of integers
+        Order of stencil for each axis (-1=infinite)
+
+    cfl: float, optional
+        Fraction of the Courant-Friedrich-Lewy criteria [1]
+
+    l_nodal: bool, optional
+        Quantities are at nodes if True, staggered otherwise
+
+    source_smoother: smoother instance, optional
+        Smoother object to apply to the sources
+
+    field_smoother: smoother instance, optional
+        Smoother object to apply to the fields
+
+    subcycling: integer, optional
+        Level of subcycling for the GPSTD solver
+
+    galilean_velocity: vector of floats, optional
+        Velocity of Galilean reference frame [m/s]
+
+    divE_cleaning: bool, optional
+        Solver uses div(E) cleaning if True
+
+    divB_cleaning: bool, optional
+        Solver uses div(B) cleaning if True
+
+    pml_divE_cleaning: bool, optional
+        Solver uses div(E) cleaning in the PML if True
+
+    pml_divB_cleaning: bool, optional
+        Solver uses div(B) cleaning in the PML if True
     """
 
     methods_list = ['Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT']
@@ -66,10 +101,20 @@ class PICMI_ElectromagneticSolver(_ClassWithInit):
 class PICMI_ElectrostaticSolver(_ClassWithInit):
     """
     Electrostatic field solver
-      - grid: grid object to be used by the solver (grid object)
-      - method = None: One of 'FFT', or 'Multigrid' (string)
-      - required_precision: Level of precision required for iterative solvers (float)
-      - maximum_iterations: Maximum number of iterations for iterative solvers (integer)
+
+    Parameters
+    ----------
+    grid: grid instance
+        Grid object for the diagnostic
+
+    method: string
+        One of 'FFT', or 'Multigrid'
+
+    required_precision: float, optional
+        Level of precision required for iterative solvers
+
+    maximum_iterations: integer, optional
+        Maximum number of iterations for iterative solvers
     """
 
     methods_list = ['FFT', 'Multigrid']
@@ -91,8 +136,14 @@ class PICMI_ElectrostaticSolver(_ClassWithInit):
 class PICMI_MagnetostaticSolver(_ClassWithInit):
     """
     Magnetostatic field solver
-      - grid: grid object to be used by the solver (grid object)
-      - method = None: One of 'FFT', or 'Multigrid' (string)
+
+    Parameters
+    ----------
+    grid: grid instance
+        Grid object for the diagnostic
+
+    method: string
+        One of 'FFT', or 'Multigrid'
     """
 
     methods_list = ['FFT', 'Multigrid']
@@ -116,10 +167,20 @@ class PICMI_MagnetostaticSolver(_ClassWithInit):
 class PICMI_BinomialSmoother(_ClassWithInit):
     """
     Descibes a binomial smoother operator (applied to grids)
-    - n_pass: Number of passes along each axis (vector)
-    - compensation: Flags whether to apply comensation along each axis (vector of booleans)
-    - stride: Stride along each axis. (vector)
-    - alpha: Smoothing coefficients along each axis. (vector)
+
+    Parameters
+    ----------
+    n_pass: vector of integers
+        Number of passes along each axis
+
+    compensation: vector of booleans, optional
+        Flags whether to apply comensation along each axis
+
+    stride: vector of integers, optional
+        Stride along each axis
+
+    alpha: vector of floats, optional
+        Smoothing coefficients along each axis
     """
     def __init__(self, n_pass=None, compensation=None, stride=None, alpha=None, **kw):
         self.n_pass = n_pass
@@ -136,35 +197,76 @@ class PICMI_Cartesian1DGrid(_ClassWithInit):
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
 
-      - number_of_cells: Number of cells along each axis (number of nodes is number_of_cells+1) (vector)
-      - lower_bound: Position of the node at the lower bound (vector) [m]
-      - upper_bound: Position of the node at the upper bound (vector) [m]
-      - lower_boundary_conditions: Conditions at lower boundaries, periodic, open, dirichlet, or neumann (vector)
-      - upper_boundary_conditions: Conditions at upper boundaries, periodic, open, dirichlet, or neumann (vector)
+    Parameters
+    ----------
+    number_of_cells: vector of integers
+        Number of cells along each axis (number of nodes is number_of_cells+1)
 
-      - nx: Number of cells along X (number of nodes=nx+1)
-      - xmin: Position of first node along X [m]
-      - xmax: Position of last node along X [m]
-      - bc_xmin: Boundary condition at min X: One of periodic, open, dirichlet, or neumann
-      - bc_xmax: Boundary condition at max X: One of periodic, open, dirichlet, or neumann
+    lower_bound: vector of floats
+        Position of the node at the lower bound [m]
 
-      - moving_window_velocity: Moving frame velocity (vector) [m/s]
+    upper_bound: vector of floats
+        Position of the node at the upper bound [m]
 
-      - refined_regions: List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-                         with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-                         lo and hi being vectors of length 2 specifying the extent of the region,
-                         and refinement_factor defaulting to [2,2] (relative to next lower level)
+    lower_boundary_conditions: vector of strings
+        Conditions at lower boundaries, periodic, open, dirichlet, or neumann
 
-      - lower_bound_particles: Position of particle lower bound (vector of floats) [m]
-      - upper_bound_particles: Position of particle upper bound (vector of floats) [m]
-      - xmin_particles: Position of min particle boundary along X [m] (float)
-      - xmax_particles: Position of max particle boundary along X [m] (float)
-      - lower_boundary_conditions_particles: Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - upper_boundary_conditions_particles: Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - bc_xmin_particles: Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_xmax_particles: Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - guard_cells = None: number of guard cells used along each direction (vector of integers)
-      - pml_cells = None: number of Perfectly Matched Layer (PML) cells along each direction (vector of integers)
+    upper_boundary_conditions: vector of strings
+        Conditions at upper boundaries, periodic, open, dirichlet, or neumann
+
+    nx: integer
+        Number of cells along X (number of nodes=nx+1)
+
+    xmin: float
+        Position of first node along X [m]
+
+    xmax: float
+        Position of last node along X [m]
+
+    bc_xmin: vector of strings
+        Boundary condition at min X: One of periodic, open, dirichlet, or neumann
+
+    bc_xmax: vector of strings
+        Boundary condition at max X: One of periodic, open, dirichlet, or neumann
+
+    moving_window_velocity: vector of floats, optional
+        Moving frame velocity [m/s]
+
+    refined_regions: list of lists, optional
+        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
+        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
+        lo and hi being vectors of length 2 specifying the extent of the region,
+        and refinement_factor defaulting to [2,2] (relative to next lower level)
+
+    lower_bound_particles: vector of floats, optional
+        Position of particle lower bound [m]
+
+    upper_bound_particles: vector of floats, optional
+        Position of particle upper bound [m]
+
+    xmin_particles: float, optional
+        Position of min particle boundary along X [m]
+
+    xmax_particles: float, optional
+        Position of max particle boundary along X [m]
+
+    lower_boundary_conditions_particles: vector of strings, optional
+        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
+
+    upper_boundary_conditions_particles: vector of strings, optional
+        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
+
+    bc_xmin_particles: string, optional
+        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_xmax_particles: string, optional
+        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
+
+    guard_cells: vector of integers, optional
+        Number of guard cells used along each direction
+
+    pml_cells: vector of integers, optional
+        Number of Perfectly Matched Layer (PML) cells along each direction
     """
     # Note for implementations, as a matter of convenience and flexibility, the user interface allows
     # specifying various quantities using either the individual named attributes (such as nx) or a
@@ -287,45 +389,106 @@ class PICMI_CylindricalGrid(_ClassWithInit):
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
 
-      - number_of_cells: Number of cells along each axis (number of nodes is number_of_cells+1) (vector)
-      - lower_bound: Position of the node at the lower bound (vector) [m]
-      - upper_bound: Position of the node at the upper bound (vector) [m]
-      - lower_boundary_conditions: Conditions at lower boundaries, periodic, open, dirichlet, or neumann (vector)
-      - upper_boundary_conditions: Conditions at upper boundaries, periodic, open, dirichlet, or neumann (vector)
+    Parameters
+    ----------
+    number_of_cells: vector of integers
+        Number of cells along each axis (number of nodes is number_of_cells+1)
 
-      - nr: Number of cells along R (number of nodes=nr+1)
-      - nz: Number of cells along Z (number of nodes=nz+1)
-      - n_azimuthal_modes: Number of azimuthal modes
-      - rmin: Position of first node along R [m]
-      - rmax: Position of last node along R [m]
-      - zmin: Position of first node along Z [m]
-      - zmax: Position of last node along Z [m]
-      - bc_rmin: Boundary condition at min R: One of open, dirichlet, or neumann
-      - bc_rmax: Boundary condition at max R: One of open, dirichlet, or neumann
-      - bc_zmin: Boundary condition at min Z: One of periodic, open, dirichlet, or neumann
-      - bc_zmax: Boundary condition at max Z: One of periodic, open, dirichlet, or neumann
+    lower_bound: vector of floats
+        Position of the node at the lower bound [m]
 
-      - moving_window_velocity: Moving frame velocity (vector) [m/s]
+    upper_bound: vector of floats
+        Position of the node at the upper bound [m]
 
-      - refined_regions: List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-                         with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-                         lo and hi being vectors of length 2 specifying the extent of the region,
-                         and refinement_factor defaulting to [2,2] (relative to next lower level)
+    lower_boundary_conditions: vector of strings
+        Conditions at lower boundaries, periodic, open, dirichlet, or neumann
 
-      - lower_bound_particles: Position of particle lower bound (vector of floats) [m]
-      - upper_bound_particles: Position of particle upper bound (vector of floats) [m]
-      - rmin_particles: Position of min particle boundary along R [m] (float)
-      - rmax_particles: Position of max particle boundary along R [m] (float)
-      - zmin_particles: Position of min particle boundary along Z [m] (float)
-      - zmax_particles: Position of max particle boundary along Z [m] (float)
-      - lower_boundary_conditions_particles: Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - upper_boundary_conditions_particles: Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - bc_rmin_particles: Boundary condition at min R for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_rmax_particles: Boundary condition at max R for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_zmin_particles: Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_zmax_particles: Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal (string)
-      - guard_cells = None: number of guard cells used along each direction (vector of integers)
-      - pml_cells = None: number of Perfectly Matched Layer (PML) cells along each direction (vector of integers)
+    upper_boundary_conditions: vector of strings
+        Conditions at upper boundaries, periodic, open, dirichlet, or neumann
+
+    nr: integer
+        Number of cells along R (number of nodes=nr+1)
+
+    nz: integer
+        Number of cells along Z (number of nodes=nz+1)
+
+    n_azimuthal_modes: integer
+        Number of azimuthal modes
+
+    rmin: float
+        Position of first node along R [m]
+
+    rmax: float
+        Position of last node along R [m]
+
+    zmin: float
+        Position of first node along Z [m]
+
+    zmax: float
+        Position of last node along Z [m]
+
+    bc_rmin: vector of strings
+        Boundary condition at min R: One of open, dirichlet, or neumann
+
+    bc_rmax: vector of strings
+        Boundary condition at max R: One of open, dirichlet, or neumann
+
+    bc_zmin: vector of strings
+        Boundary condition at min Z: One of periodic, open, dirichlet, or neumann
+
+    bc_zmax: vector of strings
+        Boundary condition at max Z: One of periodic, open, dirichlet, or neumann
+
+    moving_window_velocity: vector of floats, optional
+        Moving frame velocity [m/s]
+
+    refined_regions: list of lists, optional
+        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
+        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
+        lo and hi being vectors of length 2 specifying the extent of the region,
+        and refinement_factor defaulting to [2,2] (relative to next lower level)
+
+    lower_bound_particles: vector of floats, optional
+        Position of particle lower bound [m]
+
+    upper_bound_particles: vector of floats, optional
+        Position of particle upper bound [m]
+
+    rmin_particles: float, optional
+        Position of min particle boundary along R [m]
+
+    rmax_particles: float, optional
+        Position of max particle boundary along R [m]
+
+    zmin_particles: float, optional
+        Position of min particle boundary along Z [m]
+
+    zmax_particles: float, optional
+        Position of max particle boundary along Z [m]
+
+    lower_boundary_conditions_particles: vector of strings, optional
+        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
+
+    upper_boundary_conditions_particles: vector of strings, optional
+        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
+
+    bc_rmin_particles: string, optional
+        Boundary condition at min R for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_rmax_particles: string, optional
+        Boundary condition at max R for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_zmin_particles: string, optional
+        Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_zmax_particles: string, optional
+        Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal
+
+    guard_cells: vector of integers, optional
+        Number of guard cells used along each direction
+
+    pml_cells: vector of integers, optional
+        Number of Perfectly Matched Layer (PML) cells along each direction
     """
     # Note for implementations, as a matter of convenience and flexibility, the user interface allows
     # specifying various quantities using either the individual named attributes (such as nr and nz) or a
@@ -356,7 +519,7 @@ class PICMI_CylindricalGrid(_ClassWithInit):
         assert (upper_bound is None) and (rmax is not None and zmax is not None) or \
                (upper_bound is not None) and (rmax is None and zmax is None), \
                 Exception('Either upper_bound or rmax and zmax must be specified')
-        # --- Allow bc_rmin to be None since it will usually be the axis.
+        # --Allow bc_rmin to be None since it will usually be the axis.
         assert (lower_boundary_conditions is None) and (bc_zmin is not None) or \
                (lower_boundary_conditions is not None) and (bc_rmin is None and bc_zmin is None), \
                 Exception('Either lower_boundary_conditions or bc_rmin and bc_zmin must be specified')
@@ -449,44 +612,103 @@ class PICMI_Cartesian2DGrid(_ClassWithInit):
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
 
-      - number_of_cells: Number of cells along each axis (number of nodes is number_of_cells+1) (vector)
-      - lower_bound: Position of the node at the lower bound (vector) [m]
-      - upper_bound: Position of the node at the upper bound (vector) [m]
-      - lower_boundary_conditions: Conditions at lower boundaries, periodic, open, dirichlet, or neumann (vector)
-      - upper_boundary_conditions: Conditions at upper boundaries, periodic, open, dirichlet, or neumann (vector)
+    Parameters
+    ----------
+    number_of_cells: vector of integers
+        Number of cells along each axis (number of nodes is number_of_cells+1)
 
-      - nx: Number of cells along X (number of nodes=nx+1)
-      - ny: Number of cells along Y (number of nodes=ny+1)
-      - xmin: Position of first node along X [m]
-      - xmax: Position of last node along X [m]
-      - ymin: Position of first node along Y [m]
-      - ymax: Position of last node along Y [m]
-      - bc_xmin: Boundary condition at min X: One of periodic, open, dirichlet, or neumann
-      - bc_xmax: Boundary condition at max X: One of periodic, open, dirichlet, or neumann
-      - bc_ymin: Boundary condition at min Y: One of periodic, open, dirichlet, or neumann
-      - bc_ymax: Boundary condition at max Y: One of periodic, open, dirichlet, or neumann
+    lower_bound: vector of floats
+        Position of the node at the lower bound [m]
 
-      - moving_window_velocity: Moving frame velocity (vector) [m/s]
+    upper_bound: vector of floats
+        Position of the node at the upper bound [m]
 
-      - refined_regions: List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-                         with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-                         lo and hi being vectors of length 2 specifying the extent of the region,
-                         and refinement_factor defaulting to [2,2] (relative to next lower level)
+    lower_boundary_conditions: vector of strings
+        Conditions at lower boundaries, periodic, open, dirichlet, or neumann
 
-      - lower_bound_particles: Position of particle lower bound (vector of floats) [m]
-      - upper_bound_particles: Position of particle upper bound (vector of floats) [m]
-      - xmin_particles: Position of min particle boundary along X [m] (float)
-      - xmax_particles: Position of max particle boundary along X [m] (float)
-      - ymin_particles: Position of min particle boundary along Y [m] (float)
-      - ymax_particles: Position of max particle boundary along Y [m] (float)
-      - lower_boundary_conditions_particles: Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - upper_boundary_conditions_particles: Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - bc_xmin_particles: Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_xmax_particles: Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_ymin_particles: Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_ymax_particles: Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal (string)
-      - guard_cells = None: number of guard cells used along each direction (vector of integers)
-      - pml_cells = None: number of Perfectly Matched Layer (PML) cells along each direction (vector of integers)
+    upper_boundary_conditions: vector of strings
+        Conditions at upper boundaries, periodic, open, dirichlet, or neumann
+
+    nx: integer
+        Number of cells along X (number of nodes=nx+1)
+
+    ny: integer
+        Number of cells along Y (number of nodes=ny+1)
+
+    xmin: float
+        Position of first node along X [m]
+
+    xmax: float
+        Position of last node along X [m]
+
+    ymin: float
+        Position of first node along Y [m]
+
+    ymax: float
+        Position of last node along Y [m]
+
+    bc_xmin: vector of strings
+        Boundary condition at min X: One of periodic, open, dirichlet, or neumann
+
+    bc_xmax: vector of strings
+        Boundary condition at max X: One of periodic, open, dirichlet, or neumann
+
+    bc_ymin: vector of strings
+        Boundary condition at min Y: One of periodic, open, dirichlet, or neumann
+
+    bc_ymax: vector of strings
+        Boundary condition at max Y: One of periodic, open, dirichlet, or neumann
+
+    moving_window_velocity: vector of floats, optional
+        Moving frame velocity [m/s]
+
+    refined_regions: list of lists, optional
+        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
+        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
+        lo and hi being vectors of length 2 specifying the extent of the region,
+        and refinement_factor defaulting to [2,2] (relative to next lower level)
+
+    lower_bound_particles: vector of floats, optional
+        Position of particle lower bound [m]
+
+    upper_bound_particles: vector of floats, optional
+        Position of particle upper bound [m]
+
+    xmin_particles: float, optional
+        Position of min particle boundary along X [m]
+
+    xmax_particles: float, optional
+        Position of max particle boundary along X [m]
+
+    ymin_particles: float, optional
+        Position of min particle boundary along Y [m]
+
+    ymax_particles: float, optional
+        Position of max particle boundary along Y [m]
+
+    lower_boundary_conditions_particles: vector of strings, optional
+        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
+
+    upper_boundary_conditions_particles: vector of strings, optional
+        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
+
+    bc_xmin_particles: string, optional
+        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_xmax_particles: string, optional
+        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_ymin_particles: string, optional
+        Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_ymax_particles: string, optional
+        Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal
+
+    guard_cells: vector of integers, optional
+        Number of guard cells used along each direction
+
+    pml_cells: vector of integers, optional
+        Number of Perfectly Matched Layer (PML) cells along each direction
     """
     # Note for implementations, as a matter of convenience and flexibility, the user interface allows
     # specifying various quantities using either the individual named attributes (such as nx and ny) or a
@@ -611,52 +833,130 @@ class PICMI_Cartesian3DGrid(_ClassWithInit):
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
 
-      - number_of_cells: Number of cells along each axis (number of nodes is number_of_cells+1) (vector of integers)
-      - lower_bound: Position of the node at the lower bound (vector of floats) [m]
-      - upper_bound: Position of the node at the upper bound (vector of floats) [m]
-      - lower_boundary_conditions: Conditions at lower boundaries, periodic, open, dirichlet, or neumann (vector of strings)
-      - upper_boundary_conditions: Conditions at upper boundaries, periodic, open, dirichlet, or neumann (vector of strings)
+    Parameters
+    ----------
+    number_of_cells: vector of integers
+        Number of cells along each axis (number of nodes is number_of_cells+1)
 
-      - nx: Number of cells along X (number of nodes=nx+1) (integer)
-      - ny: Number of cells along Y (number of nodes=ny+1) (integer)
-      - nz: Number of cells along Z (number of nodes=nz+1) (integer)
-      - xmin: Position of first node along X [m] (float)
-      - xmax: Position of last node along X [m] (float)
-      - ymin: Position of first node along Y [m] (float)
-      - ymax: Position of last node along Y [m] (float)
-      - zmin: Position of first node along Z [m] (float)
-      - zmax: Position of last node along Z [m] (float)
-      - bc_xmin: Boundary condition at min X: One of periodic, open, dirichlet, or neumann (string)
-      - bc_xmax: Boundary condition at max X: One of periodic, open, dirichlet, or neumann (string)
-      - bc_ymin: Boundary condition at min Y: One of periodic, open, dirichlet, or neumann (string)
-      - bc_ymax: Boundary condition at max Y: One of periodic, open, dirichlet, or neumann (string)
-      - bc_zmin: Boundary condition at min Z: One of periodic, open, dirichlet, or neumann (string)
-      - bc_zmax: Boundary condition at max Z: One of periodic, open, dirichlet, or neumann (string)
-      - moving_window_velocity: Moving frame velocity (vector) [m/s]
+    lower_bound: vector of floats
+        Position of the node at the lower bound [m]
 
-      - refined_regions: List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-                         with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-                         lo and hi being vectors of length 3 specifying the extent of the region,
-                         and refinement_factor defaulting to [2,2,2] (relative to next lower level)
+    upper_bound: vector of floats
+        Position of the node at the upper bound [m]
 
-      - lower_bound_particles: Position of particle lower bound (vector of floats) [m]
-      - upper_bound_particles: Position of particle upper bound (vector of floats) [m]
-      - xmin_particles: Position of min particle boundary along X [m] (float)
-      - xmax_particles: Position of max particle boundary along X [m] (float)
-      - ymin_particles: Position of min particle boundary along Y [m] (float)
-      - ymax_particles: Position of max particle boundary along Y [m] (float)
-      - zmin_particles  Position of min particle boundary along Z [m] (float)
-      - zmax_particles: Position of max particle boundary along Z [m] (float)
-      - lower_boundary_conditions_particles: Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - upper_boundary_conditions_particles: Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal (vector of strings)
-      - bc_xmin_particles: Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_xmax_particles: Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_ymin_particles: Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_ymax_particles: Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_zmin_particles: Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal (string)
-      - bc_zmax_particles: Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal (string)
-      - guard_cells = None: number of guard cells used along each direction (vector of integers)
-      - pml_cells = None: number of Perfectly Matched Layer (PML) cells along each direction (vector of integers)
+    lower_boundary_conditions: vector of strings
+        Conditions at lower boundaries, periodic, open, dirichlet, or neumann
+
+    upper_boundary_conditions: vector of strings
+        Conditions at upper boundaries, periodic, open, dirichlet, or neumann
+
+    nx: integer
+        Number of cells along X (number of nodes=nx+1)
+
+    ny: integer
+        Number of cells along Y (number of nodes=ny+1)
+
+    nz: integer
+        Number of cells along Z (number of nodes=nz+1)
+
+    xmin: float
+        Position of first node along X [m]
+
+    xmax: float
+        Position of last node along X [m]
+
+    ymin: float
+        Position of first node along Y [m]
+
+    ymax: float
+        Position of last node along Y [m]
+
+    zmin: float
+        Position of first node along Z [m]
+
+    zmax: float
+        Position of last node along Z [m]
+
+    bc_xmin: string
+        Boundary condition at min X: One of periodic, open, dirichlet, or neumann
+
+    bc_xmax: string
+        Boundary condition at max X: One of periodic, open, dirichlet, or neumann
+
+    bc_ymin: string
+        Boundary condition at min Y: One of periodic, open, dirichlet, or neumann
+
+    bc_ymax: string
+        Boundary condition at max Y: One of periodic, open, dirichlet, or neumann
+
+    bc_zmin: string
+        Boundary condition at min Z: One of periodic, open, dirichlet, or neumann
+
+    bc_zmax: string
+        Boundary condition at max Z: One of periodic, open, dirichlet, or neumann
+
+    moving_window_velocity: vector of floats, optional
+        Moving frame velocity [m/s]
+
+    refined_regions: list of lists, optional
+        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
+        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
+        lo and hi being vectors of length 3 specifying the extent of the region,
+        and refinement_factor defaulting to [2,2,2] (relative to next lower level)
+
+    lower_bound_particles: vector of floats, optional
+        Position of particle lower bound [m]
+
+    upper_bound_particles: vector of floats, optional
+        Position of particle upper bound [m]
+
+    xmin_particles: float, optional
+        Position of min particle boundary along X [m]
+
+    xmax_particles: float, optional
+        Position of max particle boundary along X [m]
+
+    ymin_particles: float, optional
+        Position of min particle boundary along Y [m]
+
+    ymax_particles: float, optional
+        Position of max particle boundary along Y [m]
+
+    zmin_particles float, optional
+        Position of min particle boundary along Z [m]
+
+    zmax_particles: float, optional
+        Position of max particle boundary along Z [m]
+
+    lower_boundary_conditions_particles: vector of strings, optional
+        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
+
+    upper_boundary_conditions_particles: vector of strings, optional
+        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
+
+    bc_xmin_particles: string, optional
+        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_xmax_particles: string, optional
+        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_ymin_particles: string, optional
+        Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_ymax_particles: string, optional
+        Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_zmin_particles: string, optional
+        Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal
+
+    bc_zmax_particles: string, optional
+        Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal
+
+    guard_cells: vector of integers, optional
+        Number of guard cells used along each direction
+
+    pml_cells: vector of integers, optional
+        Number of Perfectly Matched Layer (PML) cells along each direction
     """
     # Note for implementations, as a matter of convenience and flexibility, the user interface allows
     # specifying various quantities using either the individual named attributes (such as nx, ny, and nz) or a
@@ -767,8 +1067,16 @@ class PICMI_Cartesian3DGrid(_ClassWithInit):
 
     def add_refined_region(self, level, lo, hi, refinement_factor=[2,2,2]):
         """Add a refined region.
-        level: the refinement level, with 1 being the first level of refinement, 2 being the second etc.
-        lo, hi: vectors of length 3 specifying the extent of the region
-        refinement_factor: defaulting to [2,2,2] (relative to next lower level)
+
+        Parameters
+        ----------
+        level: integer
+            The refinement level, with 1 being the first level of refinement, 2 being the second etc.
+
+        lo, hi: vectors of floats
+            Each is a vector of length 3 specifying the extent of the region
+
+        refinement_factor: vector of integers, optional
+            Defaulting to [2,2,2] (relative to next lower level)
         """
         self.refined_regions.append([level, lo, hi, refinement_factor])

--- a/PICMI_Python/lasers.py
+++ b/PICMI_Python/lasers.py
@@ -33,25 +33,54 @@ class PICMI_GaussianLaser(_ClassWithInit):
         formula for simplicity, but are of course taken into account by
         the code, when initializing the laser pulse away from the focal plane.
 
-    Parameters:
-    -----------
-      - wavelength: Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula
-      - waist: Waist of the Gaussian pulse at focus [m], defined as :math:`w_0` in the above formula
-      - duration: Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula
-      - focal_position=[0,0,0]: Position of the laser focus (vector) [m]
-      - centroid_position=[0,0,0]: Position of the laser centroid at time 0 (vector) [m]
-      - propagation_direction=[0,0,1]: Direction of propagation (unit vector) [1]
-      - polarization_direction=[1,0,0]: Direction of polarization (unit vector) [1]
-      - a0: Normalized vector potential at focus
-            Specify either a0 or E0 (E0 takes precedence).
-      - E0: Maximum amplitude of the laser field [V/m]
-            Specify either a0 or E0 (E0 takes precedence).
-      - phi0: Carrier envelope phase (CEP) [rad]
-      - zeta: Spatial chirp at focus (in the lab frame) [m.s]
-      - beta: Angular dispersion at focus (in the lab frame) [rad.s]
-      - phi2: Temporal chirp at focus (in the lab frame) [s^2]
-      - fill_in=True: Flags whether to fill in the empty spaced opened up when the grid moves
-      name=None: Optional name of the laser
+    Parameters
+    ----------
+    wavelength: float
+        Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula
+
+    waist: float
+        Waist of the Gaussian pulse at focus [m], defined as :math:`w_0` in the above formula
+
+    duration: float
+        Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula
+
+    focal_position: vector of floats, default=[0,0,0]
+        Position of the laser focus [m]
+
+    centroid_position: vector of floats, default=[0,0,0]
+        Position of the laser centroid at time 0 [m]
+
+    propagation_direction: unit vector of floats, default=[0,0,1]
+        Direction of propagation [1]
+
+    polarization_direction: unit vector of floats, default=[1,0,0]
+        Direction of polarization [1]
+
+    a0: float
+        Normalized vector potential at focus
+        Specify either a0 or E0 (E0 takes precedence).
+
+    E0: float
+        Maximum amplitude of the laser field [V/m]
+        Specify either a0 or E0 (E0 takes precedence).
+
+    phi0: float
+        Carrier envelope phase (CEP) [rad]
+
+    zeta: float
+        Spatial chirp at focus (in the lab frame) [m.s]
+
+    beta: float
+        Angular dispersion at focus (in the lab frame) [rad.s]
+
+    phi2: float
+        Temporal chirp at focus (in the lab frame) [s^2]
+
+    fill_in: bool, default=True
+        Flags whether to fill in the empty spaced opened up when the grid moves
+
+    name: string, optional
+        Optional name of the laser
     """
     def __init__(self, wavelength, waist, duration,
                  focal_position = [0., 0., 0.],
@@ -99,23 +128,41 @@ class PICMI_GaussianLaser(_ClassWithInit):
 class PICMI_AnalyticLaser(_ClassWithInit):
     """
     Specifies a laser with an analytically described distribution
-      - name=None: Optional name of the laser
-      - field_expression: Analytic expression describing the electric field of the laser(string) [V/m]
-                            Expression should be in terms of the position, 'X', 'Y', in the plane orthogonal
-                            to the propagation direction, and 't' the time. The expression should describe
-                            the full field, including the oscillitory component.
-                            Parameters can be used in the expression with the values given as keyword arguments.
-      - propagation_direction=[0,0,1]: Direction of propagation (unit vector) [1]
-      - polarization_direction=[1,0,0]: Direction of polarization (unit vector) [1]
 
-      Even though the parameters below should be built into the expression, some codes require
-      specified values for numerical purposes.
+    Parameters
+    ----------
+    name=None: string, optional
+        Optional name of the laser
 
-      - wavelength: Laser wavelength
-      - amax: Maximum normalized vector potential
-      - Emax: Maximum amplitude of the laser field [V/m]
-      Specify either amax or Emax (Emax takes precedence).
-      - fill_in=True: Flags whether to fill in the empty spaced opened up when the grid moves
+    field_expression: string
+        Analytic expression describing the electric field of the laser [V/m]
+        Expression should be in terms of the position, 'X', 'Y', in the plane orthogonal
+        to the propagation direction, and 't' the time. The expression should describe
+        the full field, including the oscillitory component.
+        Parameters can be used in the expression with the values given as keyword arguments.
+
+    propagation_direction: unit vector of floats, default=[0,0,1]
+        Direction of propagation [1]
+
+    polarization_direction: unit vector of floats, default=[1,0,0]
+        Direction of polarization [1]
+
+    wavelength: float, optional
+        Laser wavelength.
+        This should be built into the expression, but some codes require a specified value for numerical purposes.
+
+    amax: float, optional
+        Maximum normalized vector potential.
+        Specify either amax or Emax (Emax takes precedence).
+        This should be built into the expression, but some codes require a specified value for numerical purposes.
+
+    Emax: float, optional
+        Maximum amplitude of the laser field [V/m].
+        Specify either amax or Emax (Emax takes precedence).
+        This should be built into the expression, but some codes require a specified value for numerical purposes.
+
+    fill_in: bool, default=True
+        Flags whether to fill in the empty spaced opened up when the grid moves
     """
     def __init__(self, field_expression,
                  wavelength,
@@ -168,8 +215,14 @@ class PICMI_AnalyticLaser(_ClassWithInit):
 class PICMI_LaserAntenna(_ClassWithInit):
     """
     Specifies the laser antenna injection method
-      - position: Position of antenna launching the laser (vector) [m]
-      - normal_vector: Vector normal to antenna plane (vector) [1]
+
+    Parameters
+    ----------
+    position: vector of strings
+        Position of antenna launching the laser [m]
+
+    normal_vector: vector of strings
+        Vector normal to antenna plane [1]
     """
     def __init__(self, position, normal_vector, **kw):
 

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -17,6 +17,9 @@ from .base import _ClassWithInit
 class PICMI_Species(_ClassWithInit):
     """
     Species
+
+    Parameters
+    ----------
       - particle_type=None: A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
       - name=None: Name of the species
       - method=None: One of 'Boris', 'Vay', 'Higuera-Cary', 'Li' , 'free-streaming', and 'LLRK4' (Landau-Lifschitz radiation reaction formula with RK-4) (string)
@@ -64,6 +67,9 @@ class PICMI_MultiSpecies(_ClassWithInit):
     INCOMPLETE: proportions argument is not implemented
     Multiple species that are initialized with the same distribution
     Each parameter can be list, giving a value for each species, or a single value which is given to all species.
+
+    Parameters
+    ----------
       - particle_types: A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
       - names: Names of the species (optional)
       - charge_states: Charge states of the species (applies to atoms, use None otherwise) (optional)
@@ -155,6 +161,9 @@ class PICMI_MultiSpecies(_ClassWithInit):
 class PICMI_GaussianBunchDistribution(_ClassWithInit):
     """
     Describes a Gaussian distribution of particles
+
+    Parameters
+    ----------
       - n_physical_particles: Number of physical particles in the bunch
       - rms_bunch_size: RMS bunch size at t=0 (vector) [m]
       - rms_velocity=[0,0,0]: RMS velocity spread at t=0 (vector) [m/s]
@@ -181,6 +190,9 @@ class PICMI_GaussianBunchDistribution(_ClassWithInit):
 class PICMI_UniformDistribution(_ClassWithInit):
     """
     Describes a uniform density distribution of particles
+
+    Parameters
+    ----------
       - density: Physical number density [m^-3]
       - lower_bound=[None,None,None]: Lower bound of the distribution (vector) [m]
       - upper_bound=[None,None,None]: Upper bound of the distribution (vector) [m]
@@ -209,6 +221,9 @@ class PICMI_UniformDistribution(_ClassWithInit):
 class PICMI_AnalyticDistribution(_ClassWithInit):
     """
     Describes a uniform density plasma
+
+    Parameters
+    ----------
       - density_expression: Analytic expression describing physical number density (string) [m^-3]
                             Expression should be in terms of the position, written as 'x', 'y', and 'z'.
                             Parameters can be used in the expression with the values given as keyword arguments.
@@ -278,6 +293,9 @@ class PICMI_AnalyticDistribution(_ClassWithInit):
 class PICMI_ParticleListDistribution(_ClassWithInit):
     """
     Load particles at the specified positions and velocities
+
+    Parameters
+    ----------
       - x=0.: List of x positions of the particles [m]
       - y=0.: List of y positions of the particles [m]
       - z=0.: List of z positions of the particles [m]
@@ -339,6 +357,9 @@ class PICMI_ParticleListDistribution(_ClassWithInit):
 class PICMI_ParticleDistributionPlanarInjector(_ClassWithInit):
     """
     Describes the injection of particles from a plane
+
+    Parameters
+    ----------
       - position: Position of the particle centroid (vector) [m]
       - plane_normal: Vector normal to the plane of injection (vector) [1]
       - plane_velocity: Velocity of the plane of injection (vector) [m/s]
@@ -356,6 +377,9 @@ class PICMI_ParticleDistributionPlanarInjector(_ClassWithInit):
 class PICMI_GriddedLayout(_ClassWithInit):
     """
     Specifies a gridded layout of particles
+
+    Parameters
+    ----------
     - n_macroparticle_per_cell: number of particles per cell along each axis (vector)
     - grid: grid object specifying the grid to follow (optional)
     If not specified, the underlying grid of the code is used.
@@ -370,6 +394,9 @@ class PICMI_GriddedLayout(_ClassWithInit):
 class PICMI_PseudoRandomLayout(_ClassWithInit):
     """
     Specifies a pseudo-random layout of the particles
+
+    Parameters
+    ----------
 
     Only one of these should be specified:
     - n_macroparticles: total number of macroparticles to load

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -16,20 +16,49 @@ from .base import _ClassWithInit
 
 class PICMI_Species(_ClassWithInit):
     """
-    Species
+    Sets up the species to be simulated.
+    The species charge and mass can be specified by setting the particle type or by setting them directly.
+    If the particle type is specified, the charge or mass can be set to override the value from the type.
 
     Parameters
     ----------
-      - particle_type=None: A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
-      - name=None: Name of the species
-      - method=None: One of 'Boris', 'Vay', 'Higuera-Cary', 'Li' , 'free-streaming', and 'LLRK4' (Landau-Lifschitz radiation reaction formula with RK-4) (string)
-                     code-specific method can be specified using 'other:<method>'
-      - charge_state=None: Charge state of the species (applies to atoms) [1]
-      - charge=None: Particle charge, required when type is not specified, otherwise determined from type [C]
-      - mass=None: Particle mass, required when type is not specified, otherwise determined from type [kg]
-      - initial_distribution=None: The initial distribution loaded at t=0. Must be one of the standard distributions implemented.
-      - density_scale=None: A scale factor on the density given by the initial_distribution (optional)
-      - particle_shape: Particle shape used for deposition and gather ; if None, the default from the `Simulation` object will be used. Possible values are 'NGP', 'linear', 'quadratic', 'cubic'
+    particle_type: string, optional
+        A string specifying an elementary particle, atom, or other, as defined in
+        the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
+
+    name: string, optional
+        Name of the species
+
+    method: {'Boris', 'Vay', 'Higuera-Cary', 'Li' , 'free-streaming', 'LLRK4'}
+        The particle advance method to use. Code-specific method can be specified using 'other:<method>'. The default is code
+        dependent.
+
+        - 'Boris': Standard "leap-frog" Boris advance
+        - 'Vay': 
+        - 'Higuera-Cary':
+        - 'Li' :
+        - 'free-streaming': Advance with no fields
+        - 'LLRK4': Landau-Lifschitz radiation reaction formula with RK-4)
+
+    charge_state: float, optional
+        Charge state of the species (applies only to atoms) [1]
+
+    charge: float, optional
+        Particle charge, required when type is not specified, otherwise determined from type [C]
+
+    mass: float, optional
+        Particle mass, required when type is not specified, otherwise determined from type [kg]
+
+    initial_distribution: distribution instance
+        The initial distribution loaded at t=0. Must be one of the standard distributions implemented.
+
+    density_scale: float, optional
+        A scale factor on the density given by the initial_distribution
+
+    particle_shape: {'NGP', 'linear', 'quadratic', 'cubic'}
+        Particle shape used for deposition and gather.
+        If not specified, the value from the `Simulation` object will be used.
+        Other values maybe specified that are code dependent.
     """
 
     methods_list = ['Boris' , 'Vay', 'Higuera-Cary', 'Li', 'free-streaming', 'LLRK4']
@@ -65,20 +94,39 @@ class PICMI_Species(_ClassWithInit):
 class PICMI_MultiSpecies(_ClassWithInit):
     """
     INCOMPLETE: proportions argument is not implemented
-    Multiple species that are initialized with the same distribution
+    Multiple species that are initialized with the same distribution.
     Each parameter can be list, giving a value for each species, or a single value which is given to all species.
+    The species charge and mass can be specified by setting the particle type or by setting them directly.
+    If the particle type is specified, the charge or mass can be set to override the value from the type.
 
     Parameters
     ----------
-      - particle_types: A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
-      - names: Names of the species (optional)
-      - charge_states: Charge states of the species (applies to atoms, use None otherwise) (optional)
-      - charges: Particle charges, required when type is not specified, otherwise determined from type [C]
-      - masses: Particle masses, required when type is not specified, otherwise determined from type [kg]
-      - proportions: Proportions of the initial distribution made up by each species
+    particle_types: list of strings, optional
+        A string specifying an elementary particle, atom, or other, as defined in
+        the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
 
-      - initial_distribution: Initial particle distribution, applied to all species
-      - particle_shape: Particle shape for all speecies used for deposition and gather ; if None, the default from the `Simulation` object will be used. Possible values are 'NGP', 'linear', 'quadratic', 'cubic'
+    names: list of strings, optional
+        Names of the species
+
+    charge_states: list of floats, optional
+        Charge states of the species (applies only to atoms)
+
+    charges: list of floats, optional
+        Particle charges, required when type is not specified, otherwise determined from type [C]
+
+    masses: list of floats, optional
+        Particle masses, required when type is not specified, otherwise determined from type [kg]
+
+    proportions: list of floats, optional
+        Proportions of the initial distribution made up by each species
+
+    initial_distribution: distribution instance
+        Initial particle distribution, applied to all species
+
+    particle_shape: {'NGP', 'linear', 'quadratic', 'cubic'}
+        Particle shape used for deposition and gather.
+        If not specified, the value from the `Simulation` object will be used.
+        Other values maybe specified that are code dependent.
     """
     # --- Note to developer: This class attribute needs to be set to the Species class
     # --- defined in the codes PICMI implementation.
@@ -164,12 +212,23 @@ class PICMI_GaussianBunchDistribution(_ClassWithInit):
 
     Parameters
     ----------
-      - n_physical_particles: Number of physical particles in the bunch
-      - rms_bunch_size: RMS bunch size at t=0 (vector) [m]
-      - rms_velocity=[0,0,0]: RMS velocity spread at t=0 (vector) [m/s]
-      - centroid_position=[0,0,0]: Position of the bunch centroid at t=0 (vector) [m]
-      - centroid_velocity=[0,0,0]: Velocity (gamma*V) of the bunch centroid at t=0 (vector) [m/s]
-      - velocity_divergence=[0,0,0]: Expansion rate of the bunch at t=0 (vector) [m/s/m]
+    n_physical_particles: integer
+        Number of physical particles in the bunch
+
+    rms_bunch_size: vector of floats
+        RMS bunch size at t=0 [m]
+
+    rms_velocity: vector of floats, default=[0.,0.,0.]
+        RMS velocity spread at t=0 [m/s]
+
+    centroid_position: vector of floats, default=[0.,0.,0.]
+        Position of the bunch centroid at t=0 [m]
+
+    centroid_velocity: vector of floats, default=[0.,0.,0.]
+        Velocity (gamma*V) of the bunch centroid at t=0 [m/s]
+
+    velocity_divergence: vector of floats, default=[0.,0.,0.]
+        Expansion rate of the bunch at t=0 [m/s/m]
     """
     def __init__(self,n_physical_particles, rms_bunch_size,
                  rms_velocity = [0.,0.,0.],
@@ -193,12 +252,23 @@ class PICMI_UniformDistribution(_ClassWithInit):
 
     Parameters
     ----------
-      - density: Physical number density [m^-3]
-      - lower_bound=[None,None,None]: Lower bound of the distribution (vector) [m]
-      - upper_bound=[None,None,None]: Upper bound of the distribution (vector) [m]
-      - rms_velocity=[0,0,0]: Thermal velocity spread (vector) [m/s]
-      - directed_velocity=[0,0,0]: Directed, average, velocity (vector) [m/s]
-      - fill_in: Flags whether to fill in the empty spaced opened up when the grid moves
+    density: float
+        Physical number density [m^-3]
+
+    lower_bound: vector of floats, optional
+        Lower bound of the distribution [m]
+
+    upper_bound: vector of floats, optional
+        Upper bound of the distribution [m]
+
+    rms_velocity: vector of floats, default=[0.,0.,0.]
+        Thermal velocity spread [m/s]
+
+    directed_velocity: vector of floats, default=[0.,0.,0.]
+        Directed, average, velocity [m/s]
+
+    fill_in: bool, optional
+        Flags whether to fill in the empty spaced opened up when the grid moves
     """
 
     def __init__(self, density,
@@ -224,20 +294,35 @@ class PICMI_AnalyticDistribution(_ClassWithInit):
 
     Parameters
     ----------
-      - density_expression: Analytic expression describing physical number density (string) [m^-3]
-                            Expression should be in terms of the position, written as 'x', 'y', and 'z'.
-                            Parameters can be used in the expression with the values given as keyword arguments.
-      - momentum_expressions=[None, None, None]: Analytic expressions describing the gamma*velocity for each axis (vector of strings) [m/s]
-                                                 Expressions should be in terms of the position, written as 'x', 'y', and 'z'.
-                                                 Parameters can be used in the expression with the values given as keyword arguments.
-                                                 For any axis not supplied, directed_velocity will be used.
-      - lower_bound=[None,None,None]: Lower bound of the distribution (vector) [m]
-      - upper_bound=[None,None,None]: Upper bound of the distribution (vector) [m]
-      - rms_velocity=[0,0,0]: Thermal velocity spread (vector) [m/s]
-      - directed_velocity=[0,0,0]: Directed, average, velocity (vector) [m/s]
-      - fill_in: Flags whether to fill in the empty spaced opened up when the grid moves
+    density_expression: string
+        Analytic expression describing physical number density (string) [m^-3].
+        Expression should be in terms of the position, written as 'x', 'y', and 'z'.
+        Parameters can be used in the expression with the values given as keyword arguments.
 
-      # This will create a distribution where the density is n0 below rmax and zero elsewhere.
+    momentum_expressions: list of strings
+        Analytic expressions describing the gamma*velocity for each axis [m/s].
+        Expressions should be in terms of the position, written as 'x', 'y', and 'z'.
+        Parameters can be used in the expression with the values given as keyword arguments.
+        For any axis not supplied (set to None), directed_velocity will be used.
+
+    lower_bound: vector of floats, optional
+        Lower bound of the distribution [m]
+
+    upper_bound: vector of floats, optional
+        Upper bound of the distribution [m]
+
+    rms_velocity: vector of floats, detault=[0.,0.,0.]
+        Thermal velocity spread [m/s]
+
+    directed_velocity: vector of floats, detault=[0.,0.,0.]
+        Directed, average, velocity [m/s]
+
+    fill_in: bool, optional
+        Flags whether to fill in the empty spaced opened up when the grid moves
+
+
+    This will create a distribution where the density is n0 below rmax and zero elsewhere.::
+
       dist = AnalyticDistribution(density_expression='((x**2+y**2)<rmax**2)*n0',
                                   rmax = 1.,
                                   n0 = 1.e20,
@@ -296,13 +381,26 @@ class PICMI_ParticleListDistribution(_ClassWithInit):
 
     Parameters
     ----------
-      - x=0.: List of x positions of the particles [m]
-      - y=0.: List of y positions of the particles [m]
-      - z=0.: List of z positions of the particles [m]
-      - ux=0.: List of ux positions of the particles (ux = gamma*vx) [m/s]
-      - uy=0.: List of uy positions of the particles (uy = gamma*vy) [m/s]
-      - uz=0.: List of uz positions of the particles (uz = gamma*vz) [m/s]
-      - weight: Particle weight or list of weights, number of real particles per simulation particle
+    x: float, default=0.
+        List of x positions of the particles [m]
+
+    y: float, default=0.
+        List of y positions of the particles [m]
+
+    z: float, default=0.
+        List of z positions of the particles [m]
+
+    ux: float, default=0.
+        List of ux positions of the particles (ux = gamma*vx) [m/s]
+
+    uy: float, default=0.
+        List of uy positions of the particles (uy = gamma*vy) [m/s]
+
+    uz: float, default=0.
+        List of uz positions of the particles (uz = gamma*vz) [m/s]
+
+    weight: float
+        Particle weight or list of weights, number of real particles per simulation particle
     """
     def __init__(self, x=0., y=0., z=0., ux=0., uy=0., uz=0., weight=0.,
                  **kw):
@@ -360,10 +458,16 @@ class PICMI_ParticleDistributionPlanarInjector(_ClassWithInit):
 
     Parameters
     ----------
-      - position: Position of the particle centroid (vector) [m]
-      - plane_normal: Vector normal to the plane of injection (vector) [1]
-      - plane_velocity: Velocity of the plane of injection (vector) [m/s]
-      - method: InPlace - method of injection. One of 'InPlace', or 'Plane'
+    position: vector of floats
+        Position of the particle centroid [m]
+
+    plane_normal: vector of floats
+        Vector normal to the plane of injection [1]
+
+    plane_velocity: vector of floats
+        Velocity of the plane of injection [m/s]
+
+    method: {'InPlace', 'Plane'}
     """
     def __init__(self, position, plane_normal, plane_velocity=[0.,0.,0.], method='InPlace', **kw):
         self.position = position
@@ -380,9 +484,12 @@ class PICMI_GriddedLayout(_ClassWithInit):
 
     Parameters
     ----------
-    - n_macroparticle_per_cell: number of particles per cell along each axis (vector)
-    - grid: grid object specifying the grid to follow (optional)
-    If not specified, the underlying grid of the code is used.
+    n_macroparticle_per_cell: vector of integers
+        Number of particles per cell along each axis
+
+    grid: grid instance, optional
+        Grid object specifying the grid to follow.
+        If not specified, the underlying grid of the code is used.
     """
     def __init__(self, n_macroparticle_per_cell, grid=None, **kw):
         self.n_macroparticle_per_cell = n_macroparticle_per_cell
@@ -397,13 +504,20 @@ class PICMI_PseudoRandomLayout(_ClassWithInit):
 
     Parameters
     ----------
+    n_macroparticles: integer
+        Total number of macroparticles to load.
+        Either this argument or n_macroparticles_per_cell should be supplied.
 
-    Only one of these should be specified:
-    - n_macroparticles: total number of macroparticles to load
-    - n_macroparticles_per_cell: number of macroparticles to load per cell
-    - seed: pseudo-random number generator seed (optional)
-    - grid: grid object specifying the grid to follow for n_macroparticles_per_cell (optional)
-    If not specified, the underlying grid of the code is used.
+    n_macroparticles_per_cell: integer
+        Number of macroparticles to load per cell.
+        Either this argument or n_macroparticles should be supplied.
+
+    seed: integer, optional
+        Pseudo-random number generator seed
+
+    grid: grid instance, optional
+        Grid object specifying the grid to follow for n_macroparticles_per_cell.
+        If not specified, the underlying grid of the code is used.
     """
     def __init__(self, n_macroparticles=None, n_macroparticles_per_cell=None, seed=None, grid=None, **kw):
 

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -16,34 +16,34 @@ class PICMI_Simulation(_ClassWithInit):
 
     Parameters
     ----------
-    solver: object
+    - solver: object
         An instance of one of the PICMI field solvers ; see :doc:`field`
         This is the field solver to be used in the simulation
 
-    time_step_size: float
+    - time_step_size: float
         Absolute time step size of the simulation [s]
         (needed if the CFL is not specified elsewhere)
 
-    max_steps: int
+    - max_steps: int
         Maximum number of time steps
         (Specify either this, or `max_time`, or use the `step` function directly)
 
-    max_time: float
+    - max_time: float
         Maximum physical time to run the simulation [s]
         (Specify either this, or `max_steps`, or use the `step` function directly)
 
-    verbose: int
+    - verbose: int
         Verbosity flag (A larger integer results in more verbose output.)
 
-    particle_shape: str
+    - particle_shape: str
         Default particle shape for species added to this simulation.
         Possible values are 'NGP', 'linear', 'quadratic', 'cubic'.
 
-    gamma_boost: float
+    - gamma_boost: float
         Lorentz factor of the boosted simulation frame.
         (Note that all input values should be in the lab frame)
 
-    kw: additional code arguments
+    - kw: additional code arguments
         Code specific arguments ; should be prefixed with the `codename`
     """
 

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -103,17 +103,32 @@ class PICMI_Simulation(_ClassWithInit):
 
 
     def add_species_through_plane(self, species, layout,
-        injection_plane_position, injection_plane_normal_vector,
-        initialize_self_field=None ):
+                                  injection_plane_position, injection_plane_normal_vector,
+                                  initialize_self_field=None):
         """
-        Add species to be used in the simulation
+        Add species to be used in the simulation that are injected through a plane
+        during the simulation.
 
         Parameters
         ----------
-        Same as `add_species`, with the following two possible arguments:
+        - species : object
+              an instance of one of the PICMI species object ; see :doc:`species`
+              Defines added species from the *physical* point of view
+              (e.g. charge, mass, initial distribution of particles)
 
-        - injection_plane_position: Position of one point of the injection plane (vector of floats)
-        - injection_plane_normal_vector: Vector normal to injection plane (vector of floats)
+        - layout : object
+              an instance of one of the PICMI layout object ; see :doc:`layout`
+              Defines how particles are added into the simulation, from the *numerical* point of view
+
+        - initialize_self_field : bool
+              Whether the initial space-charge fields of this species
+              is calculated and added to the simulation
+
+        - injection_plane_position: vector of floats
+              Position of one point of the injection plane
+
+        - injection_plane_normal_vector: vector of floats
+              Vector normal to injection plane
         """
         self.species.append(species)
         self.layouts.append(layout)
@@ -128,18 +143,18 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-          - laser_profile: object
-                one of laser profile objects
-                Specifies the **physical** properties of the laser pulse.
-                (e.g. spatial and temporal profile, wavelength, amplitude, etc.)
+        - laser_profile: object
+              one of laser profile objects
+              Specifies the **physical** properties of the laser pulse.
+              (e.g. spatial and temporal profile, wavelength, amplitude, etc.)
 
-          - injection_method: object (optional)
-                a laser injector object (optional)
-                Specifies how the laser is injected (numerically) into the simulation
-                (e.g. through a laser antenna, or directly added to the mesh).
-                This argument describes an **algorithm**, not a physical object.
-                It is optional. (It is up to each code to define the default method
-                of injection, if the user does not provide injection_method)
+        - injection_method: object (optional)
+              a laser injector object (optional)
+              Specifies how the laser is injected (numerically) into the simulation
+              (e.g. through a laser antenna, or directly added to the mesh).
+              This argument describes an **algorithm**, not a physical object.
+              It is optional. (It is up to each code to define the default method
+              of injection, if the user does not provide injection_method)
         """
         self.lasers.append(laser)
         self.laser_injection_methods.append(injection_method)
@@ -150,17 +165,20 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-          - applied_field: object
-                one of the applied field objects
-                Specifies the properties of the applied field.
+        - applied_field: object
+              one of the applied field objects
+              Specifies the properties of the applied field.
         """
         self.applied_fields.append(applied_field)
 
     def add_diagnostic(self, diagnostic):
         """
         Add a diagnostic
-          - diagnostic: object
-                One of the diagnostic objects.
+
+        Parameters
+        ----------
+        - diagnostic: object
+              One of the diagnostic objects.
         """
         self.diagnostics.append(diagnostic)
 
@@ -174,8 +192,8 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameter
         ---------
-        max_steps: int
-            Maximum number of time steps
+        - max_steps: int
+              Maximum number of time steps
         """
         self.max_steps = max_steps
 
@@ -189,8 +207,8 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        file_name: str
-            The path to the file that will be created.
+        - file_name: str
+              The path to the file that will be created.
         """
         raise NotImplementedError
 
@@ -200,14 +218,14 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        nsteps: int
-            The number of timesteps
+        - nsteps: int
+              The number of timesteps
         """
         raise NotImplementedError
 
     def extension(self):
         """
-        Reserved for code-specific extensions, for example a class instance
+        Reserved for code-specific extensions, for example returns a class instance
         that has further methods for manipulating a PIC simulation.
         """
         raise NotImplementedError

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -16,35 +16,31 @@ class PICMI_Simulation(_ClassWithInit):
 
     Parameters
     ----------
-    - solver: object
-        An instance of one of the PICMI field solvers ; see :doc:`field`
-        This is the field solver to be used in the simulation
+    solver: field solver instance
+        This is the field solver to be used in the simulation.
+        See :doc:`field` for the list of solvers.
 
-    - time_step_size: float
-        Absolute time step size of the simulation [s]
-        (needed if the CFL is not specified elsewhere)
+    time_step_size: float
+        Absolute time step size of the simulation [s].
+        Needed if the CFL is not specified elsewhere.
 
-    - max_steps: int
-        Maximum number of time steps
-        (Specify either this, or `max_time`, or use the `step` function directly)
+    max_steps: integer
+        Maximum number of time steps.
+        Specify either this, or `max_time`, or use the `step` function directly.
 
-    - max_time: float
-        Maximum physical time to run the simulation [s]
-        (Specify either this, or `max_steps`, or use the `step` function directly)
+    max_time: float
+        Maximum physical time to run the simulation [s].
+        Specify either this, or `max_steps`, or use the `step` function directly.
 
-    - verbose: int
-        Verbosity flag (A larger integer results in more verbose output.)
+    verbose: integer, optional
+        Verbosity flag. A larger integer results in more verbose output
 
-    - particle_shape: str
-        Default particle shape for species added to this simulation.
-        Possible values are 'NGP', 'linear', 'quadratic', 'cubic'.
+    particle_shape: {'NGP', 'linear', 'quadratic', 'cubic'}
+        Default particle shape for species added to this simulation
 
-    - gamma_boost: float
+    gamma_boost: float, optional
         Lorentz factor of the boosted simulation frame.
-        (Note that all input values should be in the lab frame)
-
-    - kw: additional code arguments
-        Code specific arguments ; should be prefixed with the `codename`
+        Note that all input values should be in the lab frame.
     """
 
     def __init__(self, solver=None, time_step_size=None, max_steps=None, max_time=None, verbose=None,
@@ -82,18 +78,18 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - species : object
-              an instance of one of the PICMI species object ; see :doc:`species`
-              Defines added species from the *physical* point of view
-              (e.g. charge, mass, initial distribution of particles)
+        species: species instance
+            An instance of one of the PICMI species object; see :doc:`species`.
+            Defines species to be added from the *physical* point of view
+            (e.g. charge, mass, initial distribution of particles).
 
-        - layout : object
-              an instance of one of the PICMI layout object ; see :doc:`layout`
-              Defines how particles are added into the simulation, from the *numerical* point of view
+        layout: layout instance
+            An instance of one of the PICMI layout object; see :doc:`layout`.
+            Defines how particles are added into the simulation, from the *numerical* point of view.
 
-        - initialize_self_field : bool
-              Whether the initial space-charge fields of this species
-              is calculated and added to the simulation
+        initialize_self_field: bool, optional
+            Whether the initial space-charge fields of this species
+            is calculated and added to the simulation
         """
         self.species.append(species)
         self.layouts.append(layout)
@@ -111,24 +107,24 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - species : object
-              an instance of one of the PICMI species object ; see :doc:`species`
-              Defines added species from the *physical* point of view
-              (e.g. charge, mass, initial distribution of particles)
+        species: species instance
+            An instance of one of the PICMI species object; see :doc:`species`.
+            Defines species to be added from the *physical* point of view
+            (e.g. charge, mass, initial distribution of particles).
 
-        - layout : object
-              an instance of one of the PICMI layout object ; see :doc:`layout`
-              Defines how particles are added into the simulation, from the *numerical* point of view
+        layout: layout instance
+            An instance of one of the PICMI layout object; see :doc:`layout`.
+            Defines how particles are added into the simulation, from the *numerical* point of view.
 
-        - initialize_self_field : bool
-              Whether the initial space-charge fields of this species
-              is calculated and added to the simulation
+        initialize_self_field: bool, optional
+            Whether the initial space-charge fields of this species
+            is calculated and added to the simulation
 
-        - injection_plane_position: vector of floats
-              Position of one point of the injection plane
+        injection_plane_position: vector of floats
+            Position of one point of the injection plane
 
-        - injection_plane_normal_vector: vector of floats
-              Vector normal to injection plane
+        injection_plane_normal_vector: vector of floats
+            Vector normal to injection plane
         """
         self.species.append(species)
         self.layouts.append(layout)
@@ -143,18 +139,17 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - laser_profile: object
-              one of laser profile objects
-              Specifies the **physical** properties of the laser pulse.
-              (e.g. spatial and temporal profile, wavelength, amplitude, etc.)
+        laser_profile: laser instance
+            One of laser profile objects; see :doc:`lasers`.
+            Specifies the **physical** properties of the laser pulse
+            (e.g. spatial and temporal profile, wavelength, amplitude, etc.).
 
-        - injection_method: object (optional)
-              a laser injector object (optional)
-              Specifies how the laser is injected (numerically) into the simulation
-              (e.g. through a laser antenna, or directly added to the mesh).
-              This argument describes an **algorithm**, not a physical object.
-              It is optional. (It is up to each code to define the default method
-              of injection, if the user does not provide injection_method)
+        injection_method: laser injection instance, optional
+            Specifies how the laser is injected (numerically) into the simulation
+            (e.g. through a laser antenna, or directly added to the mesh).
+            This argument describes an **algorithm**, not a physical object.
+            It is up to each code to define the default method
+            of injection, if the user does not provide injection_method.
         """
         self.lasers.append(laser)
         self.laser_injection_methods.append(injection_method)
@@ -165,9 +160,9 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - applied_field: object
-              one of the applied field objects
-              Specifies the properties of the applied field.
+        applied_field: applied field instance
+            One of the applied field instance; see :doc:`applied_fields`.
+            Specifies the properties of the applied field.
         """
         self.applied_fields.append(applied_field)
 
@@ -177,38 +172,38 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - diagnostic: object
-              One of the diagnostic objects.
+        diagnostic: diagnostic instance
+            One of the diagnostic objects; see :doc:`diagnostics`.
         """
         self.diagnostics.append(diagnostic)
 
     def set_max_step(self, max_steps):
         """
         Set the default number of steps for the simulation (i.e. the number
-        of steps that gets written when calling `write_input_file`)
+        of steps that gets written when calling `write_input_file`).
 
         Note: this is equivalent to passing `max_steps` as an argument,
         when initializing the `Simulation` object
 
         Parameter
         ---------
-        - max_steps: int
-              Maximum number of time steps
+        max_steps: integer
+            Maximum number of time steps
         """
         self.max_steps = max_steps
 
     def write_input_file(self, file_name):
         """
         Write the parameters of the simulation, as defined in the PICMI input,
-        into another, more code-specific input file.
+        into a code-specific input file.
 
         This can be used for codes that are not Python-driven (e.g. compiled,
         pure C++ or Fortran codes) and expect a text input in a given format.
 
         Parameters
         ----------
-        - file_name: str
-              The path to the file that will be created.
+        file_name: string
+            The path to the file that will be created
         """
         raise NotImplementedError
 
@@ -218,8 +213,8 @@ class PICMI_Simulation(_ClassWithInit):
 
         Parameters
         ----------
-        - nsteps: int
-              The number of timesteps
+        nsteps: integer, default=1
+            The number of timesteps
         """
         raise NotImplementedError
 


### PR DESCRIPTION
This PR is reformatting the doc strings to a standard format that produces consistent html documentation. The doc strings follow the numpydoc standard.

All of the files have been updated.