### PR TITLE
Doc: Release Workflow Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+##########
+# Python #
+##########
+*.pyc
+__pycache__
+PICMI_Python/build/
+PICMI_Python/dist/
+PICMI_Python/picmistandard.egg-info/

--- a/PICMI_Python/README.md
+++ b/PICMI_Python/README.md
@@ -51,9 +51,13 @@ Next, add a tag and push the changes to the repo:
 
 Change the tag number as needed to match the version number.
 
+Now, go to the [GitHub releases page](https://github.com/picmi-standard/picmi/releases) and create a release matching the pushed tag.
+If you are not signing your tags with GPG keys, the tagging and GitHub release can also be done in one step on this page.
+
 The final step is to update the version on PyPI. It is recommended to use the twine command. Here are the commands:
 
   ```
+  cd PICMI_Python
   python setup.py sdist bdist_wheel
   twine upload dist/*
   ```


### PR DESCRIPTION
## Release Workflow Updates

- also create a GitHub release, not only a git tag
- `cd` into the right directory for packaging

# Add `.gitignore` file

- Python cache files
- Release directories