### PR TITLE
Make `species` argument optional in diagnostics

### DIFF
--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -163,8 +163,8 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
     period: integer
         Period of time steps that the diagnostic is performed
 
-    species: species instance or list of species instances or None
-        Species to write out. If None, all species are written.
+    species: species instance or list of species instances, optional
+        Species to write out. If not specified, all species are written.
         Note that the name attribute must be defined for the species.
 
     data_list: list of strings, optional
@@ -287,8 +287,8 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
     dt_snapshots: float
         Time between each snapshot in lab frame
 
-    species: species instance or list of species instances
-        Species to write out. If None, all species are written.
+    species: species instance or list of species instances, optional
+        Species to write out. If not specified, all species are written.
         Note that the name attribute must be defined for the species.
 
     data_list: list of strings, optional

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -163,8 +163,8 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
     period: integer
         Period of time steps that the diagnostic is performed
 
-    species: species instance or list of species instances
-        Species to write out.
+    species: species instance or list of species instances or None
+        Species to write out. If None, all species are written.
         Note that the name attribute must be defined for the species.
 
     data_list: list of strings, optional
@@ -187,7 +187,7 @@ class PICMI_ParticleDiagnostic(_ClassWithInit) :
         Sets the base name for the diagnostic output files
     """
 
-    def __init__(self, period, species, data_list=None,
+    def __init__(self, period, species=None, data_list=None,
                  write_dir = None,
                  step_min = None,
                  step_max = None,
@@ -288,7 +288,7 @@ class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
         Time between each snapshot in lab frame
 
     species: species instance or list of species instances
-        Species to write out.
+        Species to write out. If None, all species are written.
         Note that the name attribute must be defined for the species.
 
     data_list: list of strings, optional


### PR DESCRIPTION
This allows a convenient way to dump all species.