### PR TITLE
Add applied particle field from file

### DIFF
--- a/PICMI_Python/applied_fields.py
+++ b/PICMI_Python/applied_fields.py
@@ -167,11 +167,10 @@ class PICMI_Mirror(_ClassWithInit):
 
         self.handle_init(kw)
 
-        
-class PICMI_LoadGriddedField(_ClassWithInit):
+class PICMI_LoadAppliedField(_ClassWithInit):
     """
-    The data read in is used to initialize the E and B fields on the grid at the start of the simulation. 
-    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian, or (r,z) in Cylindrical geometry. 
+    The E and B fields read from file are applied to the particles directly. (They are not affected by the field solver.)
+    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian, or (r,z) in Cylindrical geometry.
 
     Parameters
     ----------
@@ -188,5 +187,29 @@ class PICMI_LoadGriddedField(_ClassWithInit):
         self.load_B = load_B
         self.load_E = load_E
         self.read_fields_from_path = read_fields_from_path
-        
+
+        self.handle_init(kw)
+
+
+class PICMI_LoadGriddedField(_ClassWithInit):
+    """
+    The data read in is used to initialize the E and B fields on the grid at the start of the simulation.
+    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian, or (r,z) in Cylindrical geometry.
+
+    Parameters
+    ----------
+    read_fields_from_path: string
+        Path to file with field data
+
+    load_B: bool, default=True
+        If False, do not load magnetic field
+
+    load_E: bool, default=True
+        If False, do not load electric field
+    """
+    def __init__(self, read_fields_from_path, load_B=True, load_E=True, **kw):
+        self.load_B = load_B
+        self.load_E = load_E
+        self.read_fields_from_path = read_fields_from_path
+
         self.handle_init(kw)


### PR DESCRIPTION
This adds the ability to load external fields applied to particles from a file with PICMI. 
(Needed in https://github.com/ECP-WarpX/WarpX/pull/4997)