### PR TITLE
PICMI: NumPy 2.0 Support

### DIFF
--- a/PICMI_Python/requirements.txt
+++ b/PICMI_Python/requirements.txt
@@ -1,2 +1,2 @@
-numpy~=1.15
+numpy>=1.15
 scipy~=1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "picmistandard"
 dynamic = ["version"]
-dependencies = ["numpy~=1.15",
+dependencies = ["numpy>=1.15",
                 "scipy~=1.5"]
 description = "Python base classes for PICMI standard"
 readme = "README.md"


### PR DESCRIPTION
We can relax the version requirement of PICMI because NumPy 2.0 does not break our logic.