### PR TITLE
add PIConGPU as example for picmi implementation

### DIFF
--- a/Docs/source/how_to_use/implementing.rst
+++ b/Docs/source/how_to_use/implementing.rst
@@ -45,3 +45,4 @@ the following step:
         - `WarpX <https://github.com/ECP-WarpX/WarpX/blob/master/Python/pywarpx/picmi.py>`__
         - `Warp <https://bitbucket.org/berkeleylab/warp/src/master/scripts/picmi.py>`__
         - `FBPIC <https://github.com/fbpic/fbpic/tree/dev/fbpic/picmi>`__
+        - `PIConGPU <https://github.com/ComputationalRadiationPhysics/picongpu/tree/dev/lib/python/picongpu/picmi>`__


### PR DESCRIPTION
This PR adds the PIConGPU implementation of the PICMI standard as an example 