### PR TITLE
Add new class to load particles from an openPMD file

### DIFF
--- a/Docs/source/standard/distribution.rst
+++ b/Docs/source/standard/distribution.rst
@@ -16,3 +16,5 @@ Particle distributions
 .. autoclass:: picmistandard.PICMI_AnalyticFluxDistribution
 
 .. autoclass:: picmistandard.PICMI_ParticleListDistribution
+
+.. autoclass:: picmistandard.PICMI_FromFileDistribution

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -601,6 +601,16 @@ class PICMI_ParticleListDistribution(_ClassWithInit):
         self.handle_init(kw)
 
 
+class PICMI_FromFileDistribution(_ClassWithInit):
+    """
+    Load particles from an openPMD file.
+
+    The openPMD file must contain the attributes `position`, `momentum`, `weighting`.
+    """
+    def __init__(self, file_path, **kw):
+        self.file_path = file_path
+        self.handle_init(kw)
+
 # ------------------
 # Numeric Objects
 # ------------------


### PR DESCRIPTION
This corresponds to the option `injection_style=external_file` in WarpX.