### PR TITLE
Pydantic

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+autodoc_pydantic

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -44,8 +44,41 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinxcontrib.autodoc_pydantic',
 ]
 autodoc_member_order = 'bysource'
+
+# -- Options for autodoc_pydantic --------------------------------------------
+# Model configuration
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_model_show_validator_summary = False
+autodoc_pydantic_model_show_validator_members = False
+autodoc_pydantic_model_show_field_summary = True  # Show field summary
+autodoc_pydantic_model_show_json = False
+autodoc_pydantic_model_undoc_members = False
+autodoc_pydantic_model_members = True  # This should show individual field members with descriptions
+autodoc_pydantic_model_hide_paramlist = False  # Don't hide parameter lists - show field details
+
+# Settings configuration (same as model)
+autodoc_pydantic_settings_show_default = True
+autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_settings_show_validators = False
+autodoc_pydantic_settings_show_field_summary = True
+
+# Field configuration - show docstrings for each field
+autodoc_pydantic_field_doc_policy = "both"  # Show both Field description and docstring
+autodoc_pydantic_field_list_validators = False  # Too detailed, irrelevant for user-facing docs
+autodoc_pydantic_field_show_constraints = True
+autodoc_pydantic_field_show_default = True
+
+# General autodoc options to hide private members
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': False,  # Don't show undocumented members
+    'private-members': False,  # Don't show private members (starting with _)
+    'special-members': False,  # Don't show special members (__init__, etc.)
+    'exclude-members': '__class_vars__,__private_attributes__,__model_fields__,__pydantic_core_schema__,__pydantic_validators__,__annotations__,__pydantic_decorators__,model_config,model_post_init',
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -64,7 +97,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/Docs/source/standard/applied_field.rst
+++ b/Docs/source/standard/applied_field.rst
@@ -9,14 +9,26 @@ Constant fields
 ---------------
 
 .. autoclass:: picmistandard.PICMI_ConstantAppliedField
+    :members:
 
 Analytic fields
 ---------------
 
 .. autoclass:: picmistandard.PICMI_AnalyticAppliedField
+    :members:
 
 Refecting mirrors
 -----------------
 
 .. autoclass:: picmistandard.PICMI_Mirror
+    :members:
+
+Loading fields from file
+------------------------
+
+.. autoclass:: picmistandard.PICMI_LoadAppliedField
+    :members:
+
+.. autoclass:: picmistandard.PICMI_LoadGriddedField
+    :members:
 

--- a/Docs/source/standard/diagnostics.rst
+++ b/Docs/source/standard/diagnostics.rst
@@ -9,10 +9,16 @@ Standard PIC diagnostics
 ------------------------
 
 .. autoclass:: picmistandard.PICMI_ParticleDiagnostic
+    :members:
 
 .. autoclass:: picmistandard.PICMI_FieldDiagnostic
+    :members:
 
 .. autoclass:: picmistandard.PICMI_ElectrostaticFieldDiagnostic
+    :members:
+
+.. autoclass:: picmistandard.PICMI_ParticleBoundaryScrapingDiagnostic
+    :members:
 
 Lab-frame diagnostics
 ---------------------
@@ -20,5 +26,7 @@ Lab-frame diagnostics
 These diagnostics are used when running boosted-frame simulations.
 
 .. autoclass:: picmistandard.PICMI_LabFrameParticleDiagnostic
+    :members:
 
 .. autoclass:: picmistandard.PICMI_LabFrameFieldDiagnostic
+    :members:

--- a/Docs/source/standard/distribution.rst
+++ b/Docs/source/standard/distribution.rst
@@ -6,15 +6,25 @@ Particle distributions
    This section is currently in development.
 
 .. autoclass:: picmistandard.PICMI_GaussianBunchDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_UniformDistribution
+    :members:
+
+.. autoclass:: picmistandard.PICMI_FoilDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_UniformFluxDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_AnalyticDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_AnalyticFluxDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_ParticleListDistribution
+    :members:
 
 .. autoclass:: picmistandard.PICMI_FromFileDistribution
+    :members:

--- a/Docs/source/standard/field.rst
+++ b/Docs/source/standard/field.rst
@@ -9,13 +9,22 @@ Electromagnetic
 ---------------
 
 .. autoclass:: picmistandard.PICMI_ElectromagneticSolver
+    :members:
 
 Electrostatic
 -------------
 
 .. autoclass:: picmistandard.PICMI_ElectrostaticSolver
+    :members:
+
+Magnetostatic
+-------------
+
+.. autoclass:: picmistandard.PICMI_MagnetostaticSolver
+    :members:
 
 Smoothing
 ---------
 
 .. autoclass:: picmistandard.PICMI_BinomialSmoother
+    :members:

--- a/Docs/source/standard/grid.rst
+++ b/Docs/source/standard/grid.rst
@@ -9,18 +9,22 @@ Grids
 ---------------------
 
 .. autoclass:: picmistandard.PICMI_Cartesian3DGrid
+    :members:
 
 2D Cartesian geometry
 ---------------------
 
 .. autoclass:: picmistandard.PICMI_Cartesian2DGrid
+    :members:
 
 1D Cartesian geometry
 ---------------------
 
 .. autoclass:: picmistandard.PICMI_Cartesian1DGrid
+    :members:
 
 Cylindrical geometry
 --------------------
 
 .. autoclass:: picmistandard.PICMI_CylindricalGrid
+    :members:

--- a/Docs/source/standard/interactions.rst
+++ b/Docs/source/standard/interactions.rst
@@ -1,0 +1,13 @@
+Interactions
+============
+
+.. warning::
+
+   This section is currently in development.
+
+Field ionization
+----------------
+
+.. autoclass:: picmistandard.PICMI_FieldIonization
+    :members:
+

--- a/Docs/source/standard/laser_injectors.rst
+++ b/Docs/source/standard/laser_injectors.rst
@@ -6,3 +6,4 @@ Laser injectors
    This section is currently in development.
 
 .. autoclass:: picmistandard.PICMI_LaserAntenna
+    :members:

--- a/Docs/source/standard/laser_profiles.rst
+++ b/Docs/source/standard/laser_profiles.rst
@@ -6,5 +6,7 @@ Laser profiles
    This section is currently in development.
 
 .. autoclass:: picmistandard.PICMI_GaussianLaser
+    :members:
 
 .. autoclass:: picmistandard.PICMI_AnalyticLaser
+    :members:

--- a/Docs/source/standard/layout.rst
+++ b/Docs/source/standard/layout.rst
@@ -6,5 +6,10 @@ Particle layouts
    This section is currently in development.
 
 .. autoclass:: picmistandard.PICMI_GriddedLayout
+    :members:
 
 .. autoclass:: picmistandard.PICMI_PseudoRandomLayout
+    :members:
+
+.. autoclass:: picmistandard.PICMI_ParticleDistributionPlanarInjector
+    :members:

--- a/Docs/source/standard/simulation.rst
+++ b/Docs/source/standard/simulation.rst
@@ -5,4 +5,4 @@ The `Simulation` object is the central object in a PICMI script.
 It defines the simulation time, field solver, registered species, etc.
 
 .. autoclass:: picmistandard.PICMI_Simulation
-    :members: step, add_species, add_laser, add_applied_field, write_input_file, extension
+    :members:

--- a/Docs/source/standard/species.rst
+++ b/Docs/source/standard/species.rst
@@ -6,5 +6,7 @@ Species objects
    This section is currently in development.
 
 .. autoclass:: picmistandard.PICMI_Species
+    :members:
 
 .. autoclass:: picmistandard.PICMI_MultiSpecies
+    :members:

--- a/Docs/source/standard/standard.rst
+++ b/Docs/source/standard/standard.rst
@@ -19,6 +19,7 @@ Simulation and grid setup
    constants
    applied_field
    diagnostics
+   interactions
 
 Particles
 ---------

--- a/PICMI_Python/applied_fields.py
+++ b/PICMI_Python/applied_fields.py
@@ -1,7 +1,20 @@
 """Classes following the PICMI standard
 These should be the base classes for Python implementation of the PICMI standard
 """
+from __future__ import annotations
+import sys
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from collections.abc import Sequence
+
 import re
+
+from pydantic import Field, model_validator
 
 from .base import _ClassWithInit
 
@@ -12,116 +25,62 @@ from .base import _ClassWithInit
 
 class PICMI_ConstantAppliedField(_ClassWithInit):
     """
-    Describes a constant applied field
-
-    Parameters
-    ----------
-    Ex: float, default=0.
-        Constant Ex field [V/m]
-
-    Ey: float, default=0.
-        Constant Ey field [V/m]
-
-    Ez: float, default=0.
-        Constant Ez field [V/m]
-
-    Bx: float, default=0.
-        Constant Bx field [T]
-
-    By: float, default=0.
-        Constant By field [T]
-
-    Bz: float, default=0.
-        Constant Bz field [T]
-
-    lower_bound: vector, optional
-        Lower bound of the region where the field is applied [m].
-
-    upper_bound: vector, optional
-        Upper bound of the region where the field is applied [m]
+    Describes a constant applied field.
     """
-    def __init__(self, Ex=None, Ey=None, Ez=None, Bx=None, By=None, Bz=None,
-                 lower_bound=[None,None,None], upper_bound=[None,None,None],
-                 **kw):
-
-        self.Ex = Ex
-        self.Ey = Ey
-        self.Ez = Ez
-        self.Bx = Bx
-        self.By = By
-        self.Bz = Bz
-
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-
-        self.handle_init(kw)
+    Ex: float | None = Field(default=None, description="Constant Ex field [V/m]")
+    Ey: float | None = Field(default=None, description="Constant Ey field [V/m]")
+    Ez: float | None = Field(default=None, description="Constant Ez field [V/m]")
+    Bx: float | None = Field(default=None, description="Constant Bx field [T]")
+    By: float | None = Field(default=None, description="Constant By field [T]")
+    Bz: float | None = Field(default=None, description="Constant Bz field [T]")
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Lower bound of the region where the field is applied [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Upper bound of the region where the field is applied [m]"
+    )
 
 
 class PICMI_AnalyticAppliedField(_ClassWithInit):
     """
-    Describes an analytic applied field
+    Describes an analytic applied field.
 
     The expressions should be in terms of the position and time, written as 'x', 'y', 'z', 't'.
     Parameters can be used in the expression with the values given as additional keyword arguments.
     Expressions should be relative to the lab frame.
-
-    Parameters
-    ----------
-    Ex_expression: string, optional
-        Analytic expression describing Ex field [V/m]
-
-    Ey_expression: string, optional
-        Analytic expression describing Ey field [V/m]
-
-    Ez_expression: string, optional
-        Analytic expression describing Ez field [V/m]
-
-    Bx_expression: string, optional
-        Analytic expression describing Bx field [T]
-
-    By_expression: string, optional
-        Analytic expression describing By field [T]
-
-    Bz_expression: string, optional
-        Analytic expression describing Bz field [T]
-
-    lower_bound: vector, optional
-        Lower bound of the region where the field is applied [m].
-
-    upper_bound: vector, optional
-        Upper bound of the region where the field is applied [m]
     """
-    def __init__(self, Ex_expression=None, Ey_expression=None, Ez_expression=None,
-                       Bx_expression=None, By_expression=None, Bz_expression=None,
-                 lower_bound=[None,None,None], upper_bound=[None,None,None],
-                 **kw):
-
-        self.Ex_expression = Ex_expression
-        self.Ey_expression = Ey_expression
-        self.Ez_expression = Ez_expression
-        self.Bx_expression = Bx_expression
-        self.By_expression = By_expression
-        self.Bz_expression = Bz_expression
-
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-
-        # --- Find any user defined keywords in the kw dictionary.
-        # --- Save them and delete them from kw.
-        # --- It's up to the code to make sure that all parameters
-        # --- used in the expression are defined.
-        self.user_defined_kw = {}
-        for k in list(kw.keys()):
-            if ((self.Ex_expression is not None and re.search(r'\b%s\b'%k, self.Ex_expression)) or
-                (self.Ey_expression is not None and re.search(r'\b%s\b'%k, self.Ey_expression)) or
-                (self.Ez_expression is not None and re.search(r'\b%s\b'%k, self.Ez_expression)) or
-                (self.Bx_expression is not None and re.search(r'\b%s\b'%k, self.Bx_expression)) or
-                (self.By_expression is not None and re.search(r'\b%s\b'%k, self.By_expression)) or
-                (self.Bz_expression is not None and re.search(r'\b%s\b'%k, self.Bz_expression))):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-
-        self.handle_init(kw)
+    Ex_expression: str | None = Field(default=None, description="Analytic expression describing Ex field [V/m]")
+    Ey_expression: str | None = Field(default=None, description="Analytic expression describing Ey field [V/m]")
+    Ez_expression: str | None = Field(default=None, description="Analytic expression describing Ez field [V/m]")
+    Bx_expression: str | None = Field(default=None, description="Analytic expression describing Bx field [T]")
+    By_expression: str | None = Field(default=None, description="Analytic expression describing By field [T]")
+    Bz_expression: str | None = Field(default=None, description="Analytic expression describing Bz field [T]")
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Lower bound of the region where the field is applied [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Upper bound of the region where the field is applied [m]"
+    )
+    user_defined_kw: dict[str, Any] = Field(default_factory=dict, exclude=True, repr=False)
+    
+    @model_validator(mode='after')
+    def _extract_user_defined_kw(self) -> Self:
+        """Extract user-defined keywords from expressions"""
+        # Extract user-defined keywords from extra fields that appear in expressions
+        if self.model_extra:
+            for k in list(self.model_extra.keys()):
+                if ((self.Ex_expression is not None and re.search(rf'\b{k}\b', self.Ex_expression)) or
+                    (self.Ey_expression is not None and re.search(rf'\b{k}\b', self.Ey_expression)) or
+                    (self.Ez_expression is not None and re.search(rf'\b{k}\b', self.Ez_expression)) or
+                    (self.Bx_expression is not None and re.search(rf'\b{k}\b', self.Bx_expression)) or
+                    (self.By_expression is not None and re.search(rf'\b{k}\b', self.By_expression)) or
+                    (self.Bz_expression is not None and re.search(rf'\b{k}\b', self.Bz_expression))):
+                    self.user_defined_kw[k] = self.model_extra.pop(k)
+        return self
 
 
 class PICMI_Mirror(_ClassWithInit):
@@ -129,87 +88,43 @@ class PICMI_Mirror(_ClassWithInit):
     Describes a perfectly reflecting mirror, where the E and B fields are zeroed
     out in a plane of finite thickness.
 
-    Parameters
-    ----------
-    x_front_location: float, optional (see comment below)
-        Location in x of the front of the nirror [m]
-
-    y_front_location: float, optional (see comment below)
-        Location in y of the front of the nirror [m]
-
-    z_front_location: float, optional (see comment below)
-        Location in z of the front of the nirror [m]
-
-    depth: float, optional (see comment below)
-        Depth of the mirror [m]
-
-    number_of_cells: integer, optional (see comment below)
-        Minimum numer of cells zeroed out
-
-
     Only one of the [x,y,z]_front_location should be specified. The mirror will be set
     perpendicular to the respective direction and infinite in the others.
     The depth of the mirror will be the maximum of the specified depth and number_of_cells,
     or the code's default value if neither are specified.
     """
-
-    def __init__(self, x_front_location=None, y_front_location=None, z_front_location=None,
-                 depth=None, number_of_cells=None, **kw):
-
-        assert [x_front_location,y_front_location,z_front_location].count(None) == 2,\
-               Exception('At least one and only one of [x,y,z]_front_location should be specified.')
-
-        self.x_front_location = x_front_location
-        self.y_front_location = y_front_location
-        self.z_front_location = z_front_location
-        self.depth = depth
-        self.number_of_cells = number_of_cells
-
-        self.handle_init(kw)
+    x_front_location: float | None = Field(default=None, description="Location in x of the front of the mirror [m]")
+    y_front_location: float | None = Field(default=None, description="Location in y of the front of the mirror [m]")
+    z_front_location: float | None = Field(default=None, description="Location in z of the front of the mirror [m]")
+    depth: float | None = Field(default=None, description="Depth of the mirror [m]")
+    number_of_cells: int | None = Field(default=None, description="Minimum number of cells zeroed out")
+    
+    @model_validator(mode='after')
+    def _validate_mirror_location(self) -> Self:
+        """Validate that exactly one location is specified"""
+        locations = [self.x_front_location, self.y_front_location, self.z_front_location]
+        if locations.count(None) != 2:
+            raise ValueError('Exactly one of [x,y,z]_front_location should be specified.')
+        return self
 
 class PICMI_LoadAppliedField(_ClassWithInit):
     """
-    The E and B fields read from file are applied to the particles directly. (They are not affected by the field solver.)
-    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian, or (r,z) in Cylindrical geometry.
-
-    Parameters
-    ----------
-    read_fields_from_path: string
-        Path to file with field data
-
-    load_B: bool, default=True
-        If False, do not load magnetic field
-
-    load_E: bool, default=True
-        If False, do not load electric field
+    The E and B fields read from file are applied to the particles directly.
+    (They are not affected by the field solver.)
+    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian,
+    or (r,z) in Cylindrical geometry.
     """
-    def __init__(self, read_fields_from_path, load_B=True, load_E=True, **kw):
-        self.load_B = load_B
-        self.load_E = load_E
-        self.read_fields_from_path = read_fields_from_path
-
-        self.handle_init(kw)
+    read_fields_from_path: str = Field(description="Path to file with field data")
+    load_B: bool = Field(default=True, description="If False, do not load magnetic field")
+    load_E: bool = Field(default=True, description="If False, do not load electric field")
 
 
 class PICMI_LoadGriddedField(_ClassWithInit):
     """
     The data read in is used to initialize the E and B fields on the grid at the start of the simulation.
-    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian, or (r,z) in Cylindrical geometry.
-
-    Parameters
-    ----------
-    read_fields_from_path: string
-        Path to file with field data
-
-    load_B: bool, default=True
-        If False, do not load magnetic field
-
-    load_E: bool, default=True
-        If False, do not load electric field
+    The expected format is the file is OpenPMD with axes (x,y,z) in Cartesian,
+    or (r,z) in Cylindrical geometry.
     """
-    def __init__(self, read_fields_from_path, load_B=True, load_E=True, **kw):
-        self.load_B = load_B
-        self.load_E = load_E
-        self.read_fields_from_path = read_fields_from_path
-
-        self.handle_init(kw)
+    read_fields_from_path: str = Field(description="Path to file with field data")
+    load_B: bool = Field(default=True, description="If False, do not load magnetic field")
+    load_E: bool = Field(default=True, description="If False, do not load electric field")

--- a/PICMI_Python/base.py
+++ b/PICMI_Python/base.py
@@ -1,14 +1,26 @@
 """base code for the PICMI standard
 """
-import inspect
+from __future__ import annotations
+from typing import Any
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 import warnings
 
-codename = None
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic._internal._model_construction import ModelMetaclass
+
+
+codename: str | None = None
 
 # --- The list of supported codes is needed to allow checking for bad arguments.
 supported_codes = ['warp', 'warpx', 'fbpic']
 
-def register_codename(_codename):
+def register_codename(_codename: str) -> None:
     """This must be called by the implementing code, passing in the code name"""
     global codename
     codename = _codename
@@ -16,9 +28,9 @@ def register_codename(_codename):
 # --- This needs to be set by the implementing package (by calling register_constants).
 # --- It allows constants to be used within the picmi interface, with the constants
 # --- defined in the implementation.
-_implementation_constants = None
+_implementation_constants: Any = None
 
-def register_constants(implementation_constants):
+def register_constants(implementation_constants: Any) -> None:
     """This must be called by the implementing code, passing in the constans object
 
     Parameters
@@ -29,18 +41,23 @@ def register_constants(implementation_constants):
     global _implementation_constants
     _implementation_constants = implementation_constants
 
-def _get_constants():
+def _get_constants() -> Any:
     return _implementation_constants
 
 
-class _DocumentedMetaClass(type):
+class _DocumentedMetaClass(ModelMetaclass):
     """This is used as a metaclass that combines the __doc__ of the picmistandard base and of the implementation"""
-    def __new__(cls, name, bases, attrs):
+    def __new__(mcs, name, bases, namespace, **kwargs):
+        # For _ClassWithInit itself, override BaseModel's docstring to remove "Usage docs" link
+        if name == '_ClassWithInit' and 'BaseModel' in [b.__name__ for b in bases if hasattr(b, '__name__')]:
+            # Use only our custom docstring, not BaseModel's
+            namespace['__doc__'] = namespace.get('__doc__', '')
+        
         # "if bases" skips this for the _ClassWithInit (which has no bases)
         # "if bases[0].__doc__ is not None" skips this for the picmistandard classes since their bases[0] (i.e. _ClassWithInit)
         # has no __doc__.
-        if bases and bases[0].__doc__ is not None:
-            implementation_doc = attrs.get('__doc__', '')
+        elif bases and bases[0].__doc__ is not None:
+            implementation_doc = namespace.get('__doc__', '')
             if implementation_doc:
                 # The format of the added string is intentional.
                 # The double return "\n\n" is needed to start a new section in the documentation.
@@ -48,41 +65,107 @@ class _DocumentedMetaClass(type):
                 # (assuming PEP8 formatting).
                 # The final return "\n" assumes that the implementation doc string begins with a return,
                 # i.e. a line with only three quotes, """.
-                attrs['__doc__'] = bases[0].__doc__ + """\n\n    Implementation specific documentation\n""" + implementation_doc
+                namespace['__doc__'] = bases[0].__doc__ + """\n\n    Implementation specific documentation\n""" + implementation_doc
             else:
-                attrs['__doc__'] = bases[0].__doc__
-        return super(_DocumentedMetaClass, cls).__new__(cls, name, bases, attrs)
+                namespace['__doc__'] = bases[0].__doc__
+        return super().__new__(mcs, name, bases, namespace, **kwargs)
 
 
-class _ClassWithInit(metaclass=_DocumentedMetaClass):
-    def handle_init(self, kw):
-        # --- Grab all keywords for the current code.
-        # --- Arguments for other supported codes are ignored.
-        # --- If there is anything left over, it is an error.
-        codekw = {}
-        for k,v in kw.copy().items():
-            code = k.split('_')[0]
-            if code == codename:
-                codekw[k] = v
-                kw.pop(k)
-            elif code in supported_codes:
-                kw.pop(k)
-
-        if kw:
-            raise TypeError('Unexpected keyword argument: "%s"'%list(kw))
-
-        # --- It is expected that init strips accepted keywords from codekw.
-        self.init(codekw)
-
+class _ClassWithInit(BaseModel, metaclass=_DocumentedMetaClass):
+    """
+    Base class for all PICMI classes using Pydantic for validation and extensibility.
+    
+    This class allows code-specific extensions (e.g., warpx_* kwargs) via Pydantic's
+    extra fields mechanism while maintaining type safety for standard attributes.
+    """
+    
+    model_config = ConfigDict(
+        # Allow extra fields for code-specific extensions
+        extra='allow',
+        # Validate assignment to catch errors early
+        validate_assignment=True,
+        # Use enum values instead of enum names
+        use_enum_values=True,
+        # Allow arbitrary types for flexibility (e.g., grid objects, distribution objects)
+        arbitrary_types_allowed=True,
+    )
+    
+    # Store code-specific kwargs separately for backward compatibility
+    _code_kwargs: dict[str, Any] = PrivateAttr(default_factory=dict)
+    
+    @model_validator(mode='before')
+    @classmethod
+    def _handle_code_specific_kwargs(cls, data: Any) -> Any:
+        """
+        Process code-specific kwargs (e.g., warpx_*) before validation.
+        This maintains backward compatibility with the old handle_init pattern.
+        """
+        if not isinstance(data, dict):
+            return data
+            
+        # Make a copy to avoid mutating the input
+        data = dict(data)
+        
+        # Separate code-specific kwargs from standard kwargs
+        codekw: dict[str, Any] = {}
+        standard_kwargs: dict[str, Any] = {}
+        
+        for k, v in data.items():
+            if '_' in k:
+                code = k.split('_')[0]
+                if code == codename:
+                    codekw[k] = v
+                elif code in supported_codes:
+                    # Ignore kwargs for other supported codes
+                    pass
+                else:
+                    standard_kwargs[k] = v
+            else:
+                standard_kwargs[k] = v
+        
+        # Store code-specific kwargs for later processing
         if codekw:
-            raise TypeError("Unexpected keyword argument for %s: '%s'"%(codename, list(codekw)))
-
-    def init(self, kw):
-        # --- The implementation of this routine should use kw.pop() to retrieve input arguments from kw.
-        # --- This allows testing for any unused arguments and raising an error if found.
+            standard_kwargs['_code_kwargs'] = codekw
+        
+        return standard_kwargs
+    
+    @model_validator(mode='after')
+    def _process_code_kwargs(self) -> 'Self':
+        """
+        Process code-specific kwargs after validation.
+        This can be overridden in subclasses to handle code-specific attributes.
+        """
+        if hasattr(self, '_code_kwargs') and self._code_kwargs:
+            # Call the init method for backward compatibility
+            self.init(self._code_kwargs)
+            
+            # Check for unused code-specific kwargs
+            if self._code_kwargs:
+                raise TypeError(
+                    f"Unexpected keyword argument for {codename}: '{list(self._code_kwargs)}'"
+                )
+        return self
+    
+    def init(self, kw: dict[str, Any]) -> None:
+        """
+        The implementation of this routine should use kw.pop() to retrieve input 
+        arguments from kw. This allows testing for any unused arguments and raising 
+        an error if found.
+        
+        Subclasses can override this method to handle code-specific arguments.
+        """
         pass
-
-    def _check_unsupported_argument(self, arg_name, message=None, raise_error=False):
+    
+    def handle_init(self, kw: dict[str, Any]) -> None:
+        """
+        Legacy method for backward compatibility.
+        In Pydantic-based classes, this is handled automatically during model validation.
+        """
+        # This method is kept for backward compatibility but is largely unused
+        # in the Pydantic implementation as validation happens automatically
+        pass
+    
+    def _check_unsupported_argument(self, arg_name: str, message: str | None = None, raise_error: bool = False) -> None:
         """Raise a warning or exception if an unsupported argument was specified by the user
 
         Parameters
@@ -106,21 +189,22 @@ class _ClassWithInit(metaclass=_DocumentedMetaClass):
                 message='My code can not handle a density_scale')
 
         """
-
-        # This compares the value of the parameter with the dault value in the __init__ method.
-        # If they differ, this means that the user supplied a value, so a warning or error is raised.
-        signature = inspect.signature(self.__init__)
-        default_value = signature.parameters[arg_name].default
-        if not (getattr(self, arg_name) == default_value):
-            full_message = f'{self.__name__}: For argument {arg_name} is not supported.'
-            if message is not None:
-                full_message += f' {message}'
-            if raise_error:
-                raise Exception(full_message)
-            else:
-                warnings.warn(full_message)
-
-    def _unsupported_value(self, arg_name, message='', raise_error=True):
+        # Get the field info from the Pydantic model
+        if arg_name in self.model_fields:
+            field_info = self.model_fields[arg_name]
+            default_value = field_info.default
+            if default_value is not ...:
+                current_value = getattr(self, arg_name, None)
+                if not (current_value == default_value):
+                    full_message = f'{self.__class__.__name__}: For argument {arg_name} is not supported.'
+                    if message is not None:
+                        full_message += f' {message}'
+                    if raise_error:
+                        raise Exception(full_message)
+                    else:
+                        warnings.warn(full_message)
+    
+    def _unsupported_value(self, arg_name: str, message: str = '', raise_error: bool = True) -> None:
         """Raise a warning or exception for argument with an unsupported value.
 
         Parameters
@@ -144,15 +228,16 @@ class _ClassWithInit(metaclass=_DocumentedMetaClass):
                     message='My code only supports Boris and Li')
 
         """
-        full_message = f'{self.__name__}: For argument {arg_name}, the value {getattr(self, arg_name)} is not supported.'
-        if message is not None:
+        current_value = getattr(self, arg_name, None)
+        full_message = f'{self.__class__.__name__}: For argument {arg_name}, the value {current_value} is not supported.'
+        if message:
             full_message += f' {message}'
         if raise_error:
             raise Exception(full_message)
         else:
             warnings.warn(full_message)
-
-    def _check_deprecated_argument(self, arg_name, message=None, raise_error=False):
+    
+    def _check_deprecated_argument(self, arg_name: str, message: str | None = None, raise_error: bool = False) -> None:
         """Raise a warning or exception if a deprecated argument was specified by the user
 
         Parameters
@@ -177,17 +262,17 @@ class _ClassWithInit(metaclass=_DocumentedMetaClass):
                 message='This argument is no longer needed')
 
         """
-
-        # This compares the value of the parameter with the dault value in the __init__ method.
-        # If they differ, this means that the user supplied a value, so a warning or error is raised.
-        signature = inspect.signature(self.__init__)
-        default_value = signature.parameters[arg_name].default
-        if not (getattr(self, arg_name) == default_value):
-            full_message = f'{self.__name__}: For argument {arg_name} is not supported.'
-            if message is not None:
-                full_message += f' {message}'
-            if raise_error:
-                raise Exception(full_message)
-            else:
-                warnings.warn(full_message)
+        if arg_name in self.model_fields:
+            field_info = self.model_fields[arg_name]
+            default_value = field_info.default
+            if default_value is not ...:
+                current_value = getattr(self, arg_name, None)
+                if not (current_value == default_value):
+                    full_message = f'{self.__class__.__name__}: For argument {arg_name} is deprecated.'
+                    if message is not None:
+                        full_message += f' {message}'
+                    if raise_error:
+                        raise Exception(full_message)
+                    else:
+                        warnings.warn(full_message)
 

--- a/PICMI_Python/diagnostics.py
+++ b/PICMI_Python/diagnostics.py
@@ -2,8 +2,30 @@
 These should be the base classes for Python implementation of the PICMI standard
 The classes in the file are all diagnostics related
 """
+from __future__ import annotations
+from typing import Any
+from collections.abc import Sequence
+
+from pydantic import Field, field_validator
 
 from .base import _ClassWithInit
+
+from .fields import (
+    PICMI_Cartesian1DGrid,
+    PICMI_Cartesian2DGrid,
+    PICMI_Cartesian3DGrid,
+    PICMI_CylindricalGrid,
+)
+from .particles import PICMI_Species, PICMI_MultiSpecies
+
+# Type aliases using Python 3.10+ union syntax
+PICMI_Grid = (
+    PICMI_Cartesian1DGrid
+    | PICMI_Cartesian2DGrid
+    | PICMI_Cartesian3DGrid
+    | PICMI_CylindricalGrid
+)
+PICMI_SpeciesType = PICMI_Species | PICMI_MultiSpecies
 
 # ----------------------------
 # Simulation frame diagnostics
@@ -12,248 +34,126 @@ from .base import _ClassWithInit
 
 class PICMI_FieldDiagnostic(_ClassWithInit):
     """
-    Defines the electromagnetic field diagnostics in the simulation frame
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    period: integer
-        Period of time steps that the diagnostic is performed
-
-    data_list: list of strings, optional
-        List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
-        Defaults to the output list of the implementing code.
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    step_min: integer, default=0
-        Minimum step at which diagnostics could be written
-
-    step_max: integer, default=unbounded
-        Maximum step at which diagnostics could be written
-
-    number_of_cells: vector of integers, optional
-        Number of cells in each dimension.
-        If not given, will be obtained from grid.
-
-    lower_bound: vector of floats, optional
-        Lower corner of diagnostics box in each direction.
-        If not given, will be obtained from grid.
-
-    upper_bound: vector of floats, optional
-        Higher corner of diagnostics box in each direction.
-        If not given, will be obtained from grid.
-
-    parallelio: bool, optional
-        If set to True, field diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
+    Defines the electromagnetic field diagnostics in the simulation frame.
     """
-    def __init__(self, grid, period, data_list=None,
-                 write_dir = None,
-                 step_min = None,
-                 step_max = None,
-                 number_of_cells = None,
-                 lower_bound = None,
-                 upper_bound = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'FieldDiagnostic: data_list must be a list'
-
-        self.grid = grid
-        self.period = period
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.step_min = step_min
-        self.step_max = step_max
-        self.number_of_cells = number_of_cells
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid object for the diagnostic")
+    period: int = Field(description="Period of time steps that the diagnostic is performed")
+    data_list: list[str] | None = Field(
+        default=None,
+        description="List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc. Defaults to the output list of the implementing code."
+    )
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    step_min: int | None = Field(default=None, description="Minimum step at which diagnostics could be written")
+    step_max: int | None = Field(default=None, description="Maximum step at which diagnostics could be written")
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Number of cells in each dimension. If not given, will be obtained from grid."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        description="Lower corner of diagnostics box in each direction. If not given, will be obtained from grid."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        description="Higher corner of diagnostics box in each direction. If not given, will be obtained from grid."
+    )
+    parallelio: bool | None = Field(default=None, description="If set to True, field diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('FieldDiagnostic: data_list must be a list')
+        return v
 
 
 class PICMI_ElectrostaticFieldDiagnostic(_ClassWithInit):
     """
-    Defines the electrostatic field diagnostics in the simulation frame
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    period: integer
-        Period of time steps that the diagnostic is performed
-
-    data_list: list of strings, optional
-        List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc.
-        Defaults to the output list of the implementing code.
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    step_min: integer, default=0
-        Minimum step at which diagnostics could be written
-
-    step_max: integer, default=unbounded
-        Maximum step at which diagnostics could be written
-
-    number_of_cells: vector of integers, optional
-        Number of cells in each dimension.
-        If not given, will be obtained from grid.
-
-    lower_bound: vector of floats, optional
-        Lower corner of diagnostics box in each direction.
-        If not given, will be obtained from grid.
-
-    upper_bound: vector of floats, optional
-        Higher corner of diagnostics box in each direction.
-        If not given, will be obtained from grid.
-
-    parallelio: bool, optional
-        If set to True, field diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
+    Defines the electrostatic field diagnostics in the simulation frame.
     """
-    def __init__(self, grid, period, data_list=None,
-                 write_dir = None,
-                 step_min = None,
-                 step_max = None,
-                 number_of_cells = None,
-                 lower_bound = None,
-                 upper_bound = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'ElectrostaticFieldDiagnostic: data_list must be a list'
-
-        self.grid = grid
-        self.period = period
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.step_min = step_min
-        self.step_max = step_max
-        self.number_of_cells = number_of_cells
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid object for the diagnostic")
+    period: int = Field(description="Period of time steps that the diagnostic is performed")
+    data_list: list[str] | None = Field(
+        default=None,
+        description="List of quantities to write out. Possible values 'rho', 'E', 'B', 'Ex' etc. Defaults to the output list of the implementing code."
+    )
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    step_min: int | None = Field(default=None, description="Minimum step at which diagnostics could be written")
+    step_max: int | None = Field(default=None, description="Maximum step at which diagnostics could be written")
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Number of cells in each dimension. If not given, will be obtained from grid."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        description="Lower corner of diagnostics box in each direction. If not given, will be obtained from grid."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        description="Higher corner of diagnostics box in each direction. If not given, will be obtained from grid."
+    )
+    parallelio: bool | None = Field(default=None, description="If set to True, field diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('ElectrostaticFieldDiagnostic: data_list must be a list')
+        return v
 
 
 class PICMI_ParticleDiagnostic(_ClassWithInit) :
     """
-    Defines the particle diagnostics in the simulation frame
-
-    Parameters
-    ----------
-    period: integer
-        Period of time steps that the diagnostic is performed
-
-    species: species instance or list of species instances, optional
-        Species to write out. If not specified, all species are written.
-        Note that the name attribute must be defined for the species.
-
-    data_list: list of strings, optional
-        The data to be written out. Possible values 'position', 'momentum', 'weighting'.
-        Defaults to the output list of the implementing code.
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    step_min: integer, default=0
-        Minimum step at which diagnostics could be written
-
-    step_max: integer, default=unbounded
-        Maximum step at which diagnostics could be written
-
-    parallelio: bool, optional
-        If set to True, particle diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
+    Defines the particle diagnostics in the simulation frame.
     """
-
-    def __init__(self, period, species=None, data_list=None,
-                 write_dir = None,
-                 step_min = None,
-                 step_max = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'ParticleDiagnostic: data_list must be a list'
-
-        self.period = period
-        self.species = species
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.step_min = step_min
-        self.step_max = step_max
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    period: int = Field(description="Period of time steps that the diagnostic is performed")
+    species: "PICMI_Species | PICMI_MultiSpecies | list[PICMI_Species | PICMI_MultiSpecies] | None" = Field(
+        default=None,
+        description="Species instance or list of species instances. Species to write out. If not specified, all species are written. Note that the name attribute must be defined for the species."
+    )
+    data_list: list[str] | None = Field(
+        default=None,
+        description="The data to be written out. Possible values 'position', 'momentum', 'weighting'. Defaults to the output list of the implementing code."
+    )
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    step_min: int | None = Field(default=None, description="Minimum step at which diagnostics could be written")
+    step_max: int | None = Field(default=None, description="Maximum step at which diagnostics could be written")
+    parallelio: bool | None = Field(default=None, description="If set to True, particle diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('ParticleDiagnostic: data_list must be a list')
+        return v
 
 
 class PICMI_ParticleBoundaryScrapingDiagnostic(_ClassWithInit) :
     """
     Defines the particle diagnostics that are used to collect the particles that are absorbed at the boundaries, throughout the simulation.
-
-    Parameters
-    ----------
-    period: integer
-        Period of time steps that the diagnostic is performed
-
-    species: species instance or list of species instances, optional
-        Species to write out. If not specified, all species are written.
-        Note that the name attribute must be defined for the species.
-
-    data_list: list of strings, optional
-        The data to be written out. Possible values 'position', 'momentum', 'weighting'.
-        Defaults to the output list of the implementing code.
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    parallelio: bool, optional
-        If set to True, particle diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
     """
-
-    def __init__(self, period, species=None, data_list=None,
-                 write_dir = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'ParticleBoundaryScrapingDiagnostic: data_list must be a list'
-
-        self.period = period
-        self.species = species
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    period: int = Field(description="Period of time steps that the diagnostic is performed")
+    species: "PICMI_Species | PICMI_MultiSpecies | list[PICMI_Species | PICMI_MultiSpecies] | None" = Field(
+        default=None,
+        description="Species instance or list of species instances. Species to write out. If not specified, all species are written. Note that the name attribute must be defined for the species."
+    )
+    data_list: list[str] | None = Field(
+        default=None,
+        description="The data to be written out. Possible values 'position', 'momentum', 'weighting'. Defaults to the output list of the implementing code."
+    )
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    parallelio: bool | None = Field(default=None, description="If set to True, particle diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('ParticleBoundaryScrapingDiagnostic: data_list must be a list')
+        return v
 
 # ----------------------------
 # Lab frame diagnostics
@@ -262,115 +162,58 @@ class PICMI_ParticleBoundaryScrapingDiagnostic(_ClassWithInit) :
 
 class PICMI_LabFrameFieldDiagnostic(_ClassWithInit):
     """
-    Defines the electromagnetic field diagnostics in the lab frame
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    num_snapshots: integer
-        Number of lab frame snapshots to make
-
-    dt_snapshots: float
-        Time between each snapshot in lab frame
-
-    data_list: list of strings, optional
-        List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc.
-        Defaults to the output list of the implementing code.
-
-    z_subsampling: integer, default=1
-        A factor which is applied on the resolution of the lab frame reconstruction
-
-    time_start: float, default=0
-        Time for the first snapshot in lab frame
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    parallelio: bool, optional
-        If set to True, field diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
+    Defines the electromagnetic field diagnostics in the lab frame.
     """
-    def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,
-                 z_subsampling = 1, time_start = 0.,
-                 write_dir = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'LabFrameFieldDiagnostic: data_list must be a list'
-
-        self.grid = grid
-        self.num_snapshots = num_snapshots
-        self.dt_snapshots = dt_snapshots
-        self.z_subsampling = z_subsampling
-        self.time_start = time_start
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid object for the diagnostic")
+    num_snapshots: int = Field(description="Number of lab frame snapshots to make")
+    dt_snapshots: float = Field(description="Time between each snapshot in lab frame")
+    data_list: list[str] | None = Field(
+        default=None,
+        description="List of quantities to write out. Possible values 'rho', 'E', 'B', 'J', 'Ex' etc. Defaults to the output list of the implementing code."
+    )
+    z_subsampling: int = Field(
+        default=1,
+        description="A factor which is applied on the resolution of the lab frame reconstruction"
+    )
+    time_start: float = Field(
+        default=0.,
+        description="Time for the first snapshot in lab frame"
+    )
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    parallelio: bool | None = Field(default=None, description="If set to True, field diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('LabFrameFieldDiagnostic: data_list must be a list')
+        return v
 
 
 class PICMI_LabFrameParticleDiagnostic(_ClassWithInit):
     """
-    Defines the particle diagnostics in the lab frame
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    num_snapshots: integer
-        Number of lab frame snapshots to make
-
-    dt_snapshots: float
-        Time between each snapshot in lab frame
-
-    species: species instance or list of species instances, optional
-        Species to write out. If not specified, all species are written.
-        Note that the name attribute must be defined for the species.
-
-    data_list: list of strings, optional
-        The data to be written out. Possible values 'position', 'momentum', 'weighting'.
-        Defaults to the output list of the implementing code.
-
-    time_start: float, default=0
-        Time for the first snapshot in lab frame
-
-    write_dir: string, optional
-        Directory where data is to be written
-
-    parallelio: bool, optional
-        If set to True, particle diagnostics are dumped in parallel
-
-    name: string, optional
-        Sets the base name for the diagnostic output files
+    Defines the particle diagnostics in the lab frame.
     """
-    def __init__(self, grid, num_snapshots, dt_snapshots, data_list=None,
-                 time_start = 0.,
-                 species = None,
-                 write_dir = None,
-                 parallelio = None,
-                 name = None,
-                 **kw):
-
-        if data_list is not None:
-            assert isinstance(data_list, list), 'LabFrameParticleDiagnostic: data_list must be a list'
-
-        self.grid = grid
-        self.num_snapshots = num_snapshots
-        self.dt_snapshots = dt_snapshots
-        self.time_start = time_start
-        self.species = species
-        self.data_list = data_list
-        self.write_dir = write_dir
-        self.parallelio = parallelio
-        self.name = name
-
-        self.handle_init(kw)
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid object for the diagnostic")
+    num_snapshots: int = Field(description="Number of lab frame snapshots to make")
+    dt_snapshots: float = Field(description="Time between each snapshot in lab frame")
+    species: "PICMI_Species | PICMI_MultiSpecies | list[PICMI_Species | PICMI_MultiSpecies] | None" = Field(
+        default=None,
+        description="Species instance or list of species instances. Species to write out. If not specified, all species are written. Note that the name attribute must be defined for the species."
+    )
+    data_list: list[str] | None = Field(
+        default=None,
+        description="The data to be written out. Possible values 'position', 'momentum', 'weighting'. Defaults to the output list of the implementing code."
+    )
+    time_start: float = Field(default=0., description="Time for the first snapshot in lab frame")
+    write_dir: str | None = Field(default=None, description="Directory where data is to be written")
+    parallelio: bool | None = Field(default=None, description="If set to True, particle diagnostics are dumped in parallel")
+    name: str | None = Field(default=None, description="Sets the base name for the diagnostic output files")
+    
+    @field_validator('data_list')
+    @classmethod
+    def _validate_data_list(cls, v):
+        if v is not None and not isinstance(v, list):
+            raise ValueError('LabFrameParticleDiagnostic: data_list must be a list')
+        return v

--- a/PICMI_Python/fields.py
+++ b/PICMI_Python/fields.py
@@ -1,10 +1,27 @@
 """Classes following the PICMI standard
 These should be the base classes for Python implementation of the PICMI standard
 """
-import math
+from __future__ import annotations
 import sys
+from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from collections.abc import Sequence
+
+from pydantic import Field, field_validator, model_validator
 
 from .base import _ClassWithInit
+
+# Type aliases - using forward references for types defined later in this file
+# Note: Grid types are defined later in this file, so we use string forward references
+PICMI_Grid = (
+    "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | "
+    "PICMI_Cartesian3DGrid | PICMI_CylindricalGrid"
+)
 
 # ---------------
 # Physics objects
@@ -12,147 +29,122 @@ from .base import _ClassWithInit
 
 class PICMI_ElectromagneticSolver(_ClassWithInit):
     """
-    Electromagnetic field solver
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    method: {'Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT'}
-        The advance method use to solve Maxwell's equations. The default method is code dependent.
-
-        - 'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
-
-        - 'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties
-          (https://doi.org/10.1103/PhysRevSTAB.16.041303)
-
-        - 'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
-
-        - 'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
-
-        - 'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
-
-        - 'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
-
-        - 'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
-
-    stencil_order: vector of integers
-        Order of stencil for each axis (-1=infinite)
-
-    cfl: float, optional
-        Fraction of the Courant-Friedrich-Lewy criteria [1]
-
-    source_smoother: smoother instance, optional
-        Smoother object to apply to the sources
-
-    field_smoother: smoother instance, optional
-        Smoother object to apply to the fields
-
-    subcycling: integer, optional
-        Level of subcycling for the GPSTD solver
-
-    galilean_velocity: vector of floats, optional
-        Velocity of Galilean reference frame [m/s]
-
-    divE_cleaning: bool, optional
-        Solver uses div(E) cleaning if True
-
-    divB_cleaning: bool, optional
-        Solver uses div(B) cleaning if True
-
-    pml_divE_cleaning: bool, optional
-        Solver uses div(E) cleaning in the PML if True
-
-    pml_divB_cleaning: bool, optional
-        Solver uses div(B) cleaning in the PML if True
+    Electromagnetic field solver.
+    
+    The advance method used to solve Maxwell's equations. The default method is code dependent.
+    
+    Method options:
+    
+    - 'Yee': standard solver using the staggered Yee grid (https://doi.org/10.1109/TAP.1966.1138693)
+    - 'CKC': solver with the extended Cole-Karkkainen-Cowan stencil with better dispersion properties (https://doi.org/10.1103/PhysRevSTAB.16.041303)
+    - 'Lehe': CKC-style solver with modified dispersion (https://doi.org/10.1103/PhysRevSTAB.16.021301)
+    - 'PSTD': Spectral solver with finite difference in time domain, e.g., Q. H. Liu, Letters 15 (3) (1997) 158–165
+    - 'PSATD': Spectral solver with analytic in time domain (https://doi.org/10.1016/j.jcp.2013.03.010)
+    - 'DS': Directional Splitting after Yasuhiko Sentoku (https://doi.org/10.1140/epjd/e2014-50162-y)
+    - 'ECT': Enlarged Cell Technique solver, allowing internal conductors (https://doi.org/10.1109/APS.2005.1551259)
     """
-
-    methods_list = ['Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT']
-
-    def __init__(self, grid, method=None, stencil_order=None, cfl=None,
-                 source_smoother=None, field_smoother=None, subcycling=None,
-                 galilean_velocity=None, divE_cleaning=None, divB_cleaning=None,
-                 pml_divE_cleaning=None, pml_divB_cleaning=None, **kw):
-
-        assert method is None or method in PICMI_ElectromagneticSolver.methods_list, \
-               Exception('method must be one of '+', '.join(PICMI_ElectromagneticSolver.methods_list))
-
-        self.grid = grid
-        self.method = method
-        self.cfl = cfl
-        self.stencil_order = stencil_order
-        self.source_smoother = source_smoother
-        self.field_smoother = field_smoother
-        self.subcycling = subcycling
-        self.galilean_velocity = galilean_velocity
-        self.divE_cleaning = divE_cleaning
-        self.divB_cleaning = divB_cleaning
-        self.pml_divE_cleaning = pml_divE_cleaning
-        self.pml_divB_cleaning = pml_divB_cleaning
-
-        self.handle_init(kw)
+    methods_list: list[str] = ['Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT']
+    
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid object for the diagnostic")
+    method: Literal['Yee', 'CKC', 'Lehe', 'PSTD', 'PSATD', 'GPSTD', 'DS', 'ECT'] | None = Field(
+        default=None,
+        description="The advance method use to solve Maxwell's equations. The default method is code dependent."
+    )
+    stencil_order: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers. Order of stencil for each axis (-1=infinite)"
+    )
+    cfl: float | None = Field(
+        default=None,
+        description="Fraction of the Courant-Friedrich-Lewy criteria [1]"
+    )
+    source_smoother: "PICMI_BinomialSmoother | None" = Field(
+        default=None,
+        description="Smoother instance. Smoother object to apply to the sources"
+    )
+    field_smoother: "PICMI_BinomialSmoother | None" = Field(
+        default=None,
+        description="Smoother instance. Smoother object to apply to the fields"
+    )
+    subcycling: int | None = Field(
+        default=None,
+        description="Level of subcycling for the GPSTD solver"
+    )
+    galilean_velocity: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats. Velocity of Galilean reference frame [m/s]"
+    )
+    divE_cleaning: bool | None = Field(
+        default=None,
+        description="Solver uses div(E) cleaning if True"
+    )
+    divB_cleaning: bool | None = Field(
+        default=None,
+        description="Solver uses div(B) cleaning if True"
+    )
+    pml_divE_cleaning: bool | None = Field(
+        default=None,
+        description="Solver uses div(E) cleaning in the PML if True"
+    )
+    pml_divB_cleaning: bool | None = Field(
+        default=None,
+        description="Solver uses div(B) cleaning in the PML if True"
+    )
+    
+    @field_validator('method')
+    @classmethod
+    def _validate_method(cls, v):
+        if v is not None and v not in PICMI_ElectromagneticSolver.methods_list:
+            raise ValueError(f'method must be one of {", ".join(PICMI_ElectromagneticSolver.methods_list)}')
+        return v
 
 
 class PICMI_ElectrostaticSolver(_ClassWithInit):
     """
-    Electrostatic field solver
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    method: string
-        One of 'FFT', or 'Multigrid'
-
-    required_precision: float, optional
-        Level of precision required for iterative solvers
-
-    maximum_iterations: integer, optional
-        Maximum number of iterations for iterative solvers
+    Electrostatic field solver.
     """
-
-    methods_list = ['FFT', 'Multigrid']
-
-    def __init__(self, grid, method=None,
-                 required_precision=None, maximum_iterations=None, **kw):
-
-        assert method is None or method in PICMI_ElectrostaticSolver.methods_list, \
-               Exception('method must be one of '+', '.join(PICMI_ElectrostaticSolver.methods_list))
-
-        self.grid = grid
-        self.method = method
-        self.required_precision = required_precision
-        self.maximum_iterations = maximum_iterations
-
-        self.handle_init(kw)
+    methods_list: list[str] = ['FFT', 'Multigrid']
+    
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid instance. Grid object for the diagnostic")
+    method: Literal['FFT', 'Multigrid'] | None = Field(
+        default=None,
+        description="String. One of 'FFT', or 'Multigrid'"
+    )
+    required_precision: float | None = Field(
+        default=None,
+        description="Level of precision required for iterative solvers"
+    )
+    maximum_iterations: int | None = Field(
+        default=None,
+        description="Maximum number of iterations for iterative solvers"
+    )
+    
+    @field_validator('method')
+    @classmethod
+    def _validate_method(cls, v):
+        if v is not None and v not in PICMI_ElectrostaticSolver.methods_list:
+            raise ValueError(f'method must be one of {", ".join(PICMI_ElectrostaticSolver.methods_list)}')
+        return v
 
 
 class PICMI_MagnetostaticSolver(_ClassWithInit):
     """
-    Magnetostatic field solver
-
-    Parameters
-    ----------
-    grid: grid instance
-        Grid object for the diagnostic
-
-    method: string
-        One of 'FFT', or 'Multigrid'
+    Magnetostatic field solver.
     """
-
-    methods_list = ['FFT', 'Multigrid']
-
-    def __init__(self, grid, method=None, **kw):
-
-        assert method is None or method in PICMI_MagnetostaticSolver.methods_list, \
-               Exception('method must be one of '+', '.join(PICMI_MagnetostaticSolver.methods_list))
-
-        self.grid = grid
-        self.method = method
-
-        self.handle_init(kw)
+    methods_list: list[str] = ['FFT', 'Multigrid']
+    
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid" = Field(description="Grid instance. Grid object for the diagnostic")
+    method: Literal['FFT', 'Multigrid'] | None = Field(
+        default=None,
+        description="String. One of 'FFT', or 'Multigrid'"
+    )
+    
+    @field_validator('method')
+    @classmethod
+    def _validate_method(cls, v):
+        if v is not None and v not in PICMI_MagnetostaticSolver.methods_list:
+            raise ValueError(f'method must be one of {", ".join(PICMI_MagnetostaticSolver.methods_list)}')
+        return v
 
 
 # ------------------
@@ -162,107 +154,31 @@ class PICMI_MagnetostaticSolver(_ClassWithInit):
 
 class PICMI_BinomialSmoother(_ClassWithInit):
     """
-    Describes a binomial smoother operator (applied to grids)
-
-    Parameters
-    ----------
-    n_pass: vector of integers
-        Number of passes along each axis
-
-    compensation: vector of booleans, optional
-        Flags whether to apply comensation along each axis
-
-    stride: vector of integers, optional
-        Stride along each axis
-
-    alpha: vector of floats, optional
-        Smoothing coefficients along each axis
+    Describes a binomial smoother operator (applied to grids).
     """
-    def __init__(self, n_pass=None, compensation=None, stride=None, alpha=None, **kw):
-        self.n_pass = n_pass
-        self.compensation = compensation
-        self.stride = stride
-        self.alpha = alpha
-
-        self.handle_init(kw)
+    n_pass: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers. Number of passes along each axis"
+    )
+    compensation: Sequence[bool] | None = Field(
+        default=None,
+        description="Vector of booleans, optional. Flags whether to apply compensation along each axis"
+    )
+    stride: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Stride along each axis"
+    )
+    alpha: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Smoothing coefficients along each axis"
+    )
 
 
 class PICMI_Cartesian1DGrid(_ClassWithInit):
     """
-    One-dimensional Cartesian grid
+    One-dimensional Cartesian grid.
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
-
-    Parameters
-    ----------
-    number_of_cells: vector of integers
-        Number of cells along each axis (number of nodes is number_of_cells+1)
-
-    lower_bound: vector of floats
-        Position of the node at the lower bound [m]
-
-    upper_bound: vector of floats
-        Position of the node at the upper bound [m]
-
-    lower_boundary_conditions: vector of strings
-        Conditions at lower boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    upper_boundary_conditions: vector of strings
-        Conditions at upper boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    nx: integer
-        Number of cells along X (number of nodes=nx+1)
-
-    xmin: float
-        Position of first node along X [m]
-
-    xmax: float
-        Position of last node along X [m]
-
-    bc_xmin: vector of strings
-        Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_xmax: vector of strings
-        Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    moving_window_velocity: vector of floats, optional
-        Moving frame velocity [m/s]
-
-    refined_regions: list of lists, optional
-        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-        lo and hi being vectors of length 2 specifying the extent of the region,
-        and refinement_factor defaulting to [2,2] (relative to next lower level)
-
-    lower_bound_particles: vector of floats, optional
-        Position of particle lower bound [m]
-
-    upper_bound_particles: vector of floats, optional
-        Position of particle upper bound [m]
-
-    xmin_particles: float, optional
-        Position of min particle boundary along X [m]
-
-    xmax_particles: float, optional
-        Position of max particle boundary along X [m]
-
-    lower_boundary_conditions_particles: vector of strings, optional
-        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
-
-    upper_boundary_conditions_particles: vector of strings, optional
-        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
-
-    bc_xmin_particles: string, optional
-        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_xmax_particles: string, optional
-        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
-
-    guard_cells: vector of integers, optional
-        Number of guard cells used along each direction
-
-    pml_cells: vector of integers, optional
-        Number of Perfectly Matched Layer (PML) cells along each direction
 
     References
     ----------
@@ -277,111 +193,251 @@ class PICMI_Cartesian1DGrid(_ClassWithInit):
       US Particle Accelerator School (USPAS) Summer Session, Self-Consistent Simulations of Beam and Plasma Systems
       https://people.nscl.msu.edu/~lund/uspas/scs_2016/lec_adv/A1b_EM_Waves.pdf
     """
-    # Note for implementations, as a matter of convenience and flexibility, the user interface allows
-    # specifying various quantities using either the individual named attributes (such as nx) or a
-    # vector of values (such as number_of_cells). However, internally, only the vectors are saved and
-    # the implementation needs to use the those to access the user input.
+    number_of_dimensions: int = 1
 
-    number_of_dimensions = 1
+    # Vector form parameters (preferred)
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=1,
+        description="Vector of integers. Number of cells along each axis (number of nodes is number_of_cells+1). Either this or nx must be specified (not both)."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=1,
+        description="Vector of floats. Position of the node at the lower bound [m]. Either this or xmin must be specified (not both)."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=1,
+        description="Vector of floats. Position of the node at the upper bound [m]. Either this or xmax must be specified (not both)."
+    )
+    lower_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=1,
+        description="Vector of strings. Conditions at lower boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmin must be specified (not both)."
+    )
+    upper_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=1,
+        max_length=1,
+        description="Vector of strings. Conditions at upper boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmax must be specified (not both)."
+    )
 
-    def __init__(self, number_of_cells=None, lower_bound=None, upper_bound=None,
-                 lower_boundary_conditions=None, upper_boundary_conditions=None,
-                 nx=None, xmin=None, xmax=None, bc_xmin=None, bc_xmax=None,
-                 moving_window_velocity=None, refined_regions=[],lower_bound_particles=None, upper_bound_particles=None,
-                 xmin_particles=None, xmax_particles=None,
-                 lower_boundary_conditions_particles=None, upper_boundary_conditions_particles=None,
-                 bc_xmin_particles=None, bc_xmax_particles=None,
-                 guard_cells=None, pml_cells=None,
-                 **kw):
+    # Individual named parameters (alternative form)
+    nx: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along X (number of nodes=nx+1). Either this or number_of_cells must be specified (not both)."
+    )
+    xmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along X [m]. Either this or lower_bound must be specified (not both)."
+    )
+    xmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along X [m]. Either this or upper_bound must be specified (not both)."
+    )
+    bc_xmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_xmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or upper_boundary_conditions must be specified (not both)."
+    )
 
-        # Sanity check and init of input arguments related to grid parameters
-        assert (number_of_cells is None) and (nx is not None) or \
-               (number_of_cells is not None) and (nx is None), \
-                Exception('Either number_of_cells or nx must be specified')
-        assert (lower_bound is None) and (xmin is not None) or \
-               (lower_bound is not None) and (xmin is None), \
-                Exception('Either lower_bound or xmin must be specified')
-        assert (upper_bound is None) and (xmax is not None) or \
-               (upper_bound is not None) and (xmax is None), \
-                Exception('Either upper_bound or xmax must be specified')
-        assert (lower_boundary_conditions is None) and (bc_xmin is not None) or \
-               (lower_boundary_conditions is not None) and (bc_xmin is None), \
-                Exception('Either lower_boundary_conditions or bc_xmin')
-        assert (upper_boundary_conditions is None) and (bc_xmax is not None) or \
-               (upper_boundary_conditions is not None) and (bc_xmax is None), \
-                Exception('Either upper_boundary_conditions or bc_xmax must be specified')
+    # Particle boundary parameters (vector form)
+    lower_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle lower bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    upper_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle upper bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    lower_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at lower boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
+    upper_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at upper boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
 
-        if number_of_cells is None:
-            number_of_cells = [nx]
-        if lower_bound is None:
-            lower_bound = [xmin]
-        if upper_bound is None:
-            upper_bound = [xmax]
-        if lower_boundary_conditions is None:
-            lower_boundary_conditions = [bc_xmin]
-        if upper_boundary_conditions is None:
-            upper_boundary_conditions = [bc_xmax,]
+    # Particle boundary parameters (individual form)
+    xmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along X [m]."
+    )
+    xmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along X [m]."
+    )
+    bc_xmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_xmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal."
+    )
 
-        # Sanity check and init of input arguments related to particle boundary parameters
-        # By default, if not specified, particle boundary values are the same as field boundary values
-        # By default, if not specified, particle boundary conditions are the same as field boundary conditions
-        if lower_bound_particles is None:
-            if (xmin_particles is None):
-                lower_bound_particles = lower_bound
+    # Other parameters
+    moving_window_velocity: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Moving frame velocity [m/s]"
+    )
+    refined_regions: list[list] = Field(
+        default_factory=list,
+        description="List of lists, optional. List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor], with level being the refinement level (1 being first, 2 being second etc), lo and hi being vectors of length 1 specifying the extent of the region, and refinement_factor defaulting to [2] (relative to next lower level)."
+    )
+    guard_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of guard cells used along each direction"
+    )
+    pml_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of Perfectly Matched Layer (PML) cells along each direction"
+    )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_parameters(cls, data: Any) -> Any:
+        """Normalize individual parameters to vector form before validation"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Validate either/or constraints for grid parameters
+        number_of_cells = data.get('number_of_cells')
+        nx = data.get('nx')
+        if (number_of_cells is None) == (nx is None):
+            raise ValueError('Exactly one of number_of_cells or nx must be specified')
+        
+        lower_bound = data.get('lower_bound')
+        xmin = data.get('xmin')
+        if (lower_bound is None) == (xmin is None):
+            raise ValueError('Exactly one of lower_bound or xmin must be specified')
+        
+        upper_bound = data.get('upper_bound')
+        xmax = data.get('xmax')
+        if (upper_bound is None) == (xmax is None):
+            raise ValueError('Exactly one of upper_bound or xmax must be specified')
+        
+        lower_boundary_conditions = data.get('lower_boundary_conditions')
+        bc_xmin = data.get('bc_xmin')
+        if (lower_boundary_conditions is None) == (bc_xmin is None):
+            raise ValueError('Exactly one of lower_boundary_conditions or bc_xmin must be specified')
+        
+        upper_boundary_conditions = data.get('upper_boundary_conditions')
+        bc_xmax = data.get('bc_xmax')
+        if (upper_boundary_conditions is None) == (bc_xmax is None):
+            raise ValueError('Exactly one of upper_boundary_conditions or bc_xmax must be specified')
+        
+        # Convert individual parameters to vectors if vectors not provided
+        # If both provided, vector takes precedence (as per original docstring)
+        if number_of_cells is None and nx is not None:
+            data['number_of_cells'] = [nx]
+            data.pop('nx', None)
+        elif number_of_cells is not None and nx is not None:
+            data.pop('nx', None)  # Prefer vector form
+        
+        if lower_bound is None and xmin is not None:
+            data['lower_bound'] = [xmin]
+            data.pop('xmin', None)
+        elif lower_bound is not None and xmin is not None:
+            data.pop('xmin', None)
+        
+        if upper_bound is None and xmax is not None:
+            data['upper_bound'] = [xmax]
+            data.pop('xmax', None)
+        elif upper_bound is not None and xmax is not None:
+            data.pop('xmax', None)
+        
+        if lower_boundary_conditions is None and bc_xmin is not None:
+            data['lower_boundary_conditions'] = [bc_xmin]
+            data.pop('bc_xmin', None)
+        elif lower_boundary_conditions is not None and bc_xmin is not None:
+            data.pop('bc_xmin', None)
+        
+        if upper_boundary_conditions is None and bc_xmax is not None:
+            data['upper_boundary_conditions'] = [bc_xmax]
+            data.pop('bc_xmax', None)
+        elif upper_boundary_conditions is not None and bc_xmax is not None:
+            data.pop('bc_xmax', None)
+        
+        # Handle particle boundaries
+        if data.get('lower_bound_particles') is None:
+            if data.get('xmin_particles') is not None:
+                data['lower_bound_particles'] = [data.pop('xmin_particles')]
+        if data.get('upper_bound_particles') is None:
+            if data.get('xmax_particles') is not None:
+                data['upper_bound_particles'] = [data.pop('xmax_particles')]
+        if data.get('lower_boundary_conditions_particles') is None:
+            if data.get('bc_xmin_particles') is not None:
+                data['lower_boundary_conditions_particles'] = [data.pop('bc_xmin_particles')]
+        if data.get('upper_boundary_conditions_particles') is None:
+            if data.get('bc_xmax_particles') is not None:
+                data['upper_boundary_conditions_particles'] = [data.pop('bc_xmax_particles')]
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _validate_and_normalize(self) -> Self:
+        """Validate dimensions and normalize particle boundaries"""
+        
+        # Handle particle boundaries - default to field boundaries if not specified
+        if self.lower_bound_particles is None:
+            if self.xmin_particles is None:
+                self.lower_bound_particles = list(self.lower_bound)
             else:
-                lower_bound_particles = [xmin_particles]
-        if upper_bound_particles is None:
-            if (xmax_particles is None):
-                upper_bound_particles = upper_bound
+                self.lower_bound_particles = [self.xmin_particles]
+                self.xmin_particles = None
+        if self.upper_bound_particles is None:
+            if self.xmax_particles is None:
+                self.upper_bound_particles = list(self.upper_bound)
             else:
-                upper_bound_particles=[xmax_particles]
-
-        if lower_boundary_conditions_particles is None:
-            if (bc_xmin_particles is None):
-                lower_boundary_conditions_particles = lower_boundary_conditions
+                self.upper_bound_particles = [self.xmax_particles]
+                self.xmax_particles = None
+        if self.lower_boundary_conditions_particles is None:
+            if self.bc_xmin_particles is None:
+                self.lower_boundary_conditions_particles = list(self.lower_boundary_conditions)
             else:
-                lower_boundary_conditions_particles = [bc_xmin_particles]
-        if upper_boundary_conditions_particles is None:
-            if (bc_xmax_particles is None):
-                upper_boundary_conditions_particles = upper_boundary_conditions
+                self.lower_boundary_conditions_particles = [self.bc_xmin_particles]
+                self.bc_xmin_particles = None
+        if self.upper_boundary_conditions_particles is None:
+            if self.bc_xmax_particles is None:
+                self.upper_boundary_conditions_particles = list(self.upper_boundary_conditions)
             else:
-                upper_boundary_conditions_particles = [bc_xmax_particles]
-
-        # Sanity check on dimensionality of vector quantities
-        assert len(number_of_cells) == 1, Exception('Wrong number of cells specified')
-        assert len(lower_bound) == 1, Exception('Wrong number of lower bounds specified')
-        assert len(upper_bound) == 1, Exception('Wrong number of upper bounds specified')
-        assert len(lower_boundary_conditions) == 1, Exception('Wrong number of lower boundary conditions specified')
-        assert len(upper_boundary_conditions) == 1, Exception('Wrong number of upper boundary conditions specified')
-        assert len(lower_bound_particles) == 1, Exception('Wrong number of particle lower bounds specified')
-        assert len(upper_bound_particles) == 1, Exception('Wrong number of particle upper bounds specified')
-        assert len(lower_boundary_conditions_particles) == 1, Exception('Wrong number of lower particle boundary conditions specified')
-        assert len(upper_boundary_conditions_particles) == 1, Exception('Wrong number of upper particle boundary conditions specified')
-
-        self.number_of_cells = number_of_cells
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.lower_boundary_conditions = lower_boundary_conditions
-        self.upper_boundary_conditions = upper_boundary_conditions
-        self.lower_bound_particles = lower_bound_particles
-        self.upper_bound_particles = upper_bound_particles
-        self.lower_boundary_conditions_particles = lower_boundary_conditions_particles
-        self.upper_boundary_conditions_particles = upper_boundary_conditions_particles
-        self.guard_cells = guard_cells
-        self.pml_cells = pml_cells
-
-        self.moving_window_velocity = moving_window_velocity
-
-        self.refined_regions = refined_regions
-
+                self.upper_boundary_conditions_particles = [self.bc_xmax_particles]
+                self.bc_xmax_particles = None
+        
+        # Dimensions are validated by Field(min_length=1, max_length=1) constraints
+        
+        # Process refined regions
         for region in self.refined_regions:
             if len(region) == 3:
                 region.append([2])
-            assert len(region[1]) == 1, Exception('The lo extent of the refined region must be a vector of length 2')
-            assert len(region[2]) == 1, Exception('The hi extent of the refined region must be a vector of length 2')
-            assert len(region[3]) == 1, Exception('The refinement factor of the refined region must be a vector of length 2')
-
-        self.handle_init(kw)
+            if len(region[1]) != 1:
+                raise ValueError('The lo extent of the refined region must be a vector of length 1')
+            if len(region[2]) != 1:
+                raise ValueError('The hi extent of the refined region must be a vector of length 1')
+            if len(region[3]) != 1:
+                raise ValueError('The refinement factor of the refined region must be a vector of length 1')
+        
+        return self
 
     def add_refined_region(self, level, lo, hi, refinement_factor=[2]):
         """Add a refined region.
@@ -394,110 +450,9 @@ class PICMI_Cartesian1DGrid(_ClassWithInit):
 
 class PICMI_CylindricalGrid(_ClassWithInit):
     """
-    Axisymmetric, cylindrical grid
+    Axisymmetric, cylindrical grid.
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
-
-    Parameters
-    ----------
-    number_of_cells: vector of integers
-        Number of cells along each axis (number of nodes is number_of_cells+1)
-
-    lower_bound: vector of floats
-        Position of the node at the lower bound [m]
-
-    upper_bound: vector of floats
-        Position of the node at the upper bound [m]
-
-    lower_boundary_conditions: vector of strings
-        Conditions at lower boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    upper_boundary_conditions: vector of strings
-        Conditions at upper boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    nr: integer
-        Number of cells along R (number of nodes=nr+1)
-
-    nz: integer
-        Number of cells along Z (number of nodes=nz+1)
-
-    n_azimuthal_modes: integer
-        Number of azimuthal modes
-
-    rmin: float
-        Position of first node along R [m]
-
-    rmax: float
-        Position of last node along R [m]
-
-    zmin: float
-        Position of first node along Z [m]
-
-    zmax: float
-        Position of last node along Z [m]
-
-    bc_rmin: vector of strings
-        Boundary condition at min R: One of open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_rmax: vector of strings
-        Boundary condition at max R: One of open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_zmin: vector of strings
-        Boundary condition at min Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_zmax: vector of strings
-        Boundary condition at max Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    moving_window_velocity: vector of floats, optional
-        Moving frame velocity [m/s]
-
-    refined_regions: list of lists, optional
-        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-        lo and hi being vectors of length 2 specifying the extent of the region,
-        and refinement_factor defaulting to [2,2] (relative to next lower level)
-
-    lower_bound_particles: vector of floats, optional
-        Position of particle lower bound [m]
-
-    upper_bound_particles: vector of floats, optional
-        Position of particle upper bound [m]
-
-    rmin_particles: float, optional
-        Position of min particle boundary along R [m]
-
-    rmax_particles: float, optional
-        Position of max particle boundary along R [m]
-
-    zmin_particles: float, optional
-        Position of min particle boundary along Z [m]
-
-    zmax_particles: float, optional
-        Position of max particle boundary along Z [m]
-
-    lower_boundary_conditions_particles: vector of strings, optional
-        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
-
-    upper_boundary_conditions_particles: vector of strings, optional
-        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
-
-    bc_rmin_particles: string, optional
-        Boundary condition at min R for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_rmax_particles: string, optional
-        Boundary condition at max R for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_zmin_particles: string, optional
-        Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_zmax_particles: string, optional
-        Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal
-
-    guard_cells: vector of integers, optional
-        Number of guard cells used along each direction
-
-    pml_cells: vector of integers, optional
-        Number of Perfectly Matched Layer (PML) cells along each direction
 
     References
     ----------
@@ -512,114 +467,333 @@ class PICMI_CylindricalGrid(_ClassWithInit):
       US Particle Accelerator School (USPAS) Summer Session, Self-Consistent Simulations of Beam and Plasma Systems
       https://people.nscl.msu.edu/~lund/uspas/scs_2016/lec_adv/A1b_EM_Waves.pdf
     """
-    # Note for implementations, as a matter of convenience and flexibility, the user interface allows
-    # specifying various quantities using either the individual named attributes (such as nr and nz) or a
-    # vector of values (such as number_of_cells). However, internally, only the vectors are saved and
-    # the implementation needs to use the those to access the user input.
+    number_of_dimensions: int = 2
 
-    number_of_dimensions = 2
+    # Vector form parameters (preferred)
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of integers. Number of cells along each axis (number of nodes is number_of_cells+1). Either this or nr and nz must be specified (not both)."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats. Position of the node at the lower bound [m]. Either this or rmin and zmin must be specified (not both)."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats. Position of the node at the upper bound [m]. Either this or rmax and zmax must be specified (not both)."
+    )
+    lower_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings. Conditions at lower boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_rmin and bc_zmin must be specified (not both). Note: bc_rmin may be None since it will usually be the axis."
+    )
+    upper_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings. Conditions at upper boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_rmax and bc_zmax must be specified (not both)."
+    )
 
-    def __init__(self, number_of_cells=None, lower_bound=None, upper_bound=None,
-                 lower_boundary_conditions=None, upper_boundary_conditions=None,
-                 nr=None, nz=None, n_azimuthal_modes=None,
-                 rmin=None, rmax=None, zmin=None, zmax=None,
-                 bc_rmin=None, bc_rmax=None, bc_zmin=None, bc_zmax=None,
-                 moving_window_velocity=None, refined_regions=[],
-                 lower_bound_particles=None, upper_bound_particles=None,
-                 rmin_particles=None, rmax_particles=None, zmin_particles=None, zmax_particles=None,
-                 lower_boundary_conditions_particles=None, upper_boundary_conditions_particles=None,
-                 bc_rmin_particles=None, bc_rmax_particles=None, bc_zmin_particles=None, bc_zmax_particles=None,
-                 guard_cells=None, pml_cells=None, **kw):
+    # Individual named parameters (alternative form)
+    nr: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along R (number of nodes=nr+1). Either this (along with nz) or number_of_cells must be specified (not both)."
+    )
+    nz: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along Z (number of nodes=nz+1). Either this (along with nr) or number_of_cells must be specified (not both)."
+    )
+    n_azimuthal_modes: int | None = Field(
+        default=None,
+        description="Integer. Number of azimuthal modes"
+    )
+    rmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along R [m]. Either this (along with zmin) or lower_bound must be specified (not both)."
+    )
+    rmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along R [m]. Either this (along with zmax) or upper_bound must be specified (not both)."
+    )
+    zmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along Z [m]. Either this (along with rmin) or lower_bound must be specified (not both)."
+    )
+    zmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along Z [m]. Either this (along with rmax) or upper_bound must be specified (not both)."
+    )
+    bc_rmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min R: One of open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_zmin) or lower_boundary_conditions must be specified (not both). May be None since it will usually be the axis."
+    )
+    bc_rmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max R: One of open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_zmax) or upper_boundary_conditions must be specified (not both)."
+    )
+    bc_zmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_rmin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_zmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_rmax) or upper_boundary_conditions must be specified (not both)."
+    )
 
-        # Sanity check and init of input arguments related to grid parameters
-        assert (number_of_cells is None) and (nr is not None and nz is not None) or \
-               (number_of_cells is not None) and (nr is None and nz is None), \
-                Exception('Either number_of_cells or nr and nz must be specified')
-        assert (lower_bound is None) and (rmin is not None and zmin is not None) or \
-               (lower_bound is not None) and (rmin is None and zmin is None), \
-                Exception('Either lower_bound or rmin and zmin must be specified')
-        assert (upper_bound is None) and (rmax is not None and zmax is not None) or \
-               (upper_bound is not None) and (rmax is None and zmax is None), \
-                Exception('Either upper_bound or rmax and zmax must be specified')
-        # --Allow bc_rmin to be None since it will usually be the axis.
-        assert (lower_boundary_conditions is None) and (bc_zmin is not None) or \
-               (lower_boundary_conditions is not None) and (bc_rmin is None and bc_zmin is None), \
-                Exception('Either lower_boundary_conditions or bc_rmin and bc_zmin must be specified')
-        assert (upper_boundary_conditions is None) and (bc_rmax is not None and bc_zmax is not None) or \
-               (upper_boundary_conditions is not None) and (bc_rmax is None and bc_zmax is None), \
-                Exception('Either upper_boundary_conditions or bc_rmax and bc_zmax must be specified')
+    # Particle boundary parameters (vector form)
+    lower_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle lower bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    upper_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle upper bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    lower_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at lower boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
+    upper_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at upper boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
 
-        if number_of_cells is None:
-            number_of_cells = [nr, nz]
-        if lower_bound is None:
-            lower_bound = [rmin, zmin]
-        if upper_bound is None:
-            upper_bound = [rmax, zmax]
+    # Particle boundary parameters (individual form)
+    rmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along R [m]."
+    )
+    rmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along R [m]."
+    )
+    zmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along Z [m]."
+    )
+    zmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along Z [m]."
+    )
+    bc_rmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min R for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_rmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max R for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_zmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_zmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal."
+    )
+
+    # Other parameters
+    moving_window_velocity: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Moving frame velocity [m/s]"
+    )
+    refined_regions: list[list] = Field(
+        default_factory=list,
+        description="List of lists, optional. List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor], with level being the refinement level (1 being first, 2 being second etc), lo and hi being vectors of length 2 specifying the extent of the region, and refinement_factor defaulting to [2,2] (relative to next lower level)."
+    )
+    guard_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of guard cells used along each direction"
+    )
+    pml_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of Perfectly Matched Layer (PML) cells along each direction"
+    )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_parameters(cls, data: Any) -> Any:
+        """Normalize individual parameters to vector form before validation"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Validate either/or constraints for grid parameters
+        number_of_cells = data.get('number_of_cells')
+        nr = data.get('nr')
+        nz = data.get('nz')
+        if (number_of_cells is None) == ((nr is not None) and (nz is not None)):
+            raise ValueError('Exactly one of number_of_cells or (nr and nz) must be specified')
+        
+        lower_bound = data.get('lower_bound')
+        rmin = data.get('rmin')
+        zmin = data.get('zmin')
+        if (lower_bound is None) == ((rmin is not None) and (zmin is not None)):
+            raise ValueError('Exactly one of lower_bound or (rmin and zmin) must be specified')
+        
+        upper_bound = data.get('upper_bound')
+        rmax = data.get('rmax')
+        zmax = data.get('zmax')
+        if (upper_bound is None) == ((rmax is not None) and (zmax is not None)):
+            raise ValueError('Exactly one of upper_bound or (rmax and zmax) must be specified')
+        
+        lower_boundary_conditions = data.get('lower_boundary_conditions')
+        bc_rmin = data.get('bc_rmin')
+        bc_zmin = data.get('bc_zmin')
+        # Special case: bc_rmin can be None (axis), so only check bc_zmin
+        if (lower_boundary_conditions is None) and (bc_zmin is None):
+            raise ValueError('Either lower_boundary_conditions or bc_zmin (and optionally bc_rmin) must be specified')
+        if (lower_boundary_conditions is not None) and (bc_rmin is not None or bc_zmin is not None):
+            raise ValueError('Either lower_boundary_conditions or (bc_rmin and bc_zmin) must be specified (not both)')
+        
+        upper_boundary_conditions = data.get('upper_boundary_conditions')
+        bc_rmax = data.get('bc_rmax')
+        bc_zmax = data.get('bc_zmax')
+        if (upper_boundary_conditions is None) == ((bc_rmax is not None) and (bc_zmax is not None)):
+            raise ValueError('Exactly one of upper_boundary_conditions or (bc_rmax and bc_zmax) must be specified')
+        
+        # Convert individual parameters to vectors if vectors not provided
+        if number_of_cells is None and nr is not None and nz is not None:
+            data['number_of_cells'] = [nr, nz]
+            data.pop('nr', None)
+            data.pop('nz', None)
+        elif number_of_cells is not None:
+            data.pop('nr', None)
+            data.pop('nz', None)
+        
+        if lower_bound is None and rmin is not None and zmin is not None:
+            data['lower_bound'] = [rmin, zmin]
+            data.pop('rmin', None)
+            data.pop('zmin', None)
+        elif lower_bound is not None:
+            data.pop('rmin', None)
+            data.pop('zmin', None)
+        
+        if upper_bound is None and rmax is not None and zmax is not None:
+            data['upper_bound'] = [rmax, zmax]
+            data.pop('rmax', None)
+            data.pop('zmax', None)
+        elif upper_bound is not None:
+            data.pop('rmax', None)
+            data.pop('zmax', None)
+        
         if lower_boundary_conditions is None:
-            lower_boundary_conditions = [bc_rmin, bc_zmin]
-        if upper_boundary_conditions is None:
-            upper_boundary_conditions = [bc_rmax, bc_zmax]
-
-        # Sanity check and init of input arguments related to particle boundary parameters
-        # By default, if not specified, particle boundary values are the same as field boundary values
-        # By default, if not specified, particle boundary conditions are the same as field boundary conditions
-        if lower_bound_particles is None:
-            if (rmin_particles is None) and (zmin_particles is None):
-                lower_bound_particles = lower_bound
+            bc_rmin_val = data.get('bc_rmin')
+            bc_zmin_val = data.get('bc_zmin')
+            if bc_zmin_val is not None:
+                data['lower_boundary_conditions'] = [bc_rmin_val, bc_zmin_val]
+                data.pop('bc_rmin', None)
+                data.pop('bc_zmin', None)
+        else:
+            data.pop('bc_rmin', None)
+            data.pop('bc_zmin', None)
+        
+        if upper_boundary_conditions is None and bc_rmax is not None and bc_zmax is not None:
+            data['upper_boundary_conditions'] = [bc_rmax, bc_zmax]
+            data.pop('bc_rmax', None)
+            data.pop('bc_zmax', None)
+        elif upper_boundary_conditions is not None:
+            data.pop('bc_rmax', None)
+            data.pop('bc_zmax', None)
+        
+        # Handle particle boundaries
+        if data.get('lower_bound_particles') is None:
+            rmin_p = data.get('rmin_particles')
+            zmin_p = data.get('zmin_particles')
+            if rmin_p is not None or zmin_p is not None:
+                data['lower_bound_particles'] = [rmin_p, zmin_p]
+                data.pop('rmin_particles', None)
+                data.pop('zmin_particles', None)
+        if data.get('upper_bound_particles') is None:
+            rmax_p = data.get('rmax_particles')
+            zmax_p = data.get('zmax_particles')
+            if rmax_p is not None or zmax_p is not None:
+                data['upper_bound_particles'] = [rmax_p, zmax_p]
+                data.pop('rmax_particles', None)
+                data.pop('zmax_particles', None)
+        if data.get('lower_boundary_conditions_particles') is None:
+            bc_rmin_p = data.get('bc_rmin_particles')
+            bc_zmin_p = data.get('bc_zmin_particles')
+            if bc_rmin_p is not None or bc_zmin_p is not None:
+                data['lower_boundary_conditions_particles'] = [bc_rmin_p, bc_zmin_p]
+                data.pop('bc_rmin_particles', None)
+                data.pop('bc_zmin_particles', None)
+        if data.get('upper_boundary_conditions_particles') is None:
+            bc_rmax_p = data.get('bc_rmax_particles')
+            bc_zmax_p = data.get('bc_zmax_particles')
+            if bc_rmax_p is not None or bc_zmax_p is not None:
+                data['upper_boundary_conditions_particles'] = [bc_rmax_p, bc_zmax_p]
+                data.pop('bc_rmax_particles', None)
+                data.pop('bc_zmax_particles', None)
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _validate_and_normalize(self) -> Self:
+        """Validate dimensions and normalize particle boundaries"""
+        # At this point, vectors should already be set by mode='before' validator
+        # Handle particle boundaries - default to field boundaries if not specified
+        if self.lower_bound_particles is None:
+            if self.rmin_particles is None and self.zmin_particles is None:
+                self.lower_bound_particles = list(self.lower_bound)
             else:
-                lower_bound_particles = [rmin_particles, zmin_particles]
-        if upper_bound_particles is None:
-            if (rmax_particles is None) and (zmax_particles is None):
-                upper_bound_particles = upper_bound
+                self.lower_bound_particles = [self.rmin_particles, self.zmin_particles]
+                self.rmin_particles = None
+                self.zmin_particles = None
+        if self.upper_bound_particles is None:
+            if self.rmax_particles is None and self.zmax_particles is None:
+                self.upper_bound_particles = list(self.upper_bound)
             else:
-                upper_bound_particles=[rmax_particles, zmax_particles]
-
-        if lower_boundary_conditions_particles is None:
-            if (bc_rmin_particles is None) and (bc_zmin_particles is None):
-                lower_boundary_conditions_particles = lower_boundary_conditions
+                self.upper_bound_particles = [self.rmax_particles, self.zmax_particles]
+                self.rmax_particles = None
+                self.zmax_particles = None
+        if self.lower_boundary_conditions_particles is None:
+            if self.bc_rmin_particles is None and self.bc_zmin_particles is None:
+                self.lower_boundary_conditions_particles = list(self.lower_boundary_conditions)
             else:
-                lower_boundary_conditions_particles = [bc_rmin_particles, bc_zmin_particles]
-        if upper_boundary_conditions_particles is None:
-            if (bc_rmax_particles is None) and (bc_zmax_particles is None):
-                upper_boundary_conditions_particles = upper_boundary_conditions
+                self.lower_boundary_conditions_particles = [self.bc_rmin_particles, self.bc_zmin_particles]
+                self.bc_rmin_particles = None
+                self.bc_zmin_particles = None
+        if self.upper_boundary_conditions_particles is None:
+            if self.bc_rmax_particles is None and self.bc_zmax_particles is None:
+                self.upper_boundary_conditions_particles = list(self.upper_boundary_conditions)
             else:
-                upper_boundary_conditions_particles = [bc_rmax_particles, bc_zmax_particles]
-
-        # Sanity check on dimensionality of vector quantities
-        assert len(number_of_cells) == 2, Exception('Wrong number of cells specified')
-        assert len(lower_bound) == 2, Exception('Wrong number of lower bounds specified')
-        assert len(upper_bound) == 2, Exception('Wrong number of upper bounds specified')
-        assert len(lower_boundary_conditions) == 2, Exception('Wrong number of lower boundary conditions specified')
-        assert len(upper_boundary_conditions) == 2, Exception('Wrong number of upper boundary conditions specified')
-
-        self.number_of_cells = number_of_cells
-
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.lower_boundary_conditions = lower_boundary_conditions
-        self.upper_boundary_conditions = upper_boundary_conditions
-        self.lower_bound_particles = lower_bound_particles
-        self.upper_bound_particles = upper_bound_particles
-        self.lower_boundary_conditions_particles = lower_boundary_conditions_particles
-        self.upper_boundary_conditions_particles = upper_boundary_conditions_particles
-        self.guard_cells = guard_cells
-        self.pml_cells = pml_cells
-
-        self.n_azimuthal_modes = n_azimuthal_modes
-
-        self.moving_window_velocity = moving_window_velocity
-
-        self.refined_regions = refined_regions
+                self.upper_boundary_conditions_particles = [self.bc_rmax_particles, self.bc_zmax_particles]
+                self.bc_rmax_particles = None
+                self.bc_zmax_particles = None
+        
+        # Dimensions are validated by Field(min_length=2, max_length=2) constraints
+        
+        # Process refined regions
         for region in self.refined_regions:
             if len(region) == 3:
-                region.append([2,2])
-            assert len(region[1]) == 2, Exception('The lo extent of the refined region must be a vector of length 2')
-            assert len(region[2]) == 2, Exception('The hi extent of the refined region must be a vector of length 2')
-            assert len(region[3]) == 2, Exception('The refinement factor of the refined region must be a vector of length 2')
+                region.append([2, 2])
+            if len(region[1]) != 2:
+                raise ValueError('The lo extent of the refined region must be a vector of length 2')
+            if len(region[2]) != 2:
+                raise ValueError('The hi extent of the refined region must be a vector of length 2')
+            if len(region[3]) != 2:
+                raise ValueError('The refinement factor of the refined region must be a vector of length 2')
+        
+        return self
 
-        self.handle_init(kw)
-
-    def add_refined_region(self, level, lo, hi, refinement_factor=[2,2]):
+    def add_refined_region(self, level, lo, hi, refinement_factor=[2, 2]):
         """Add a refined region.
         level: the refinement level, with 1 being the first level of refinement, 2 being the second etc.
         lo, hi: vectors of length 2 specifying the extent of the region
@@ -630,107 +804,9 @@ class PICMI_CylindricalGrid(_ClassWithInit):
 
 class PICMI_Cartesian2DGrid(_ClassWithInit):
     """
-    Two dimensional Cartesian grid
+    Two dimensional Cartesian grid.
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
-
-    Parameters
-    ----------
-    number_of_cells: vector of integers
-        Number of cells along each axis (number of nodes is number_of_cells+1)
-
-    lower_bound: vector of floats
-        Position of the node at the lower bound [m]
-
-    upper_bound: vector of floats
-        Position of the node at the upper bound [m]
-
-    lower_boundary_conditions: vector of strings
-        Conditions at lower boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    upper_boundary_conditions: vector of strings
-        Conditions at upper boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    nx: integer
-        Number of cells along X (number of nodes=nx+1)
-
-    ny: integer
-        Number of cells along Y (number of nodes=ny+1)
-
-    xmin: float
-        Position of first node along X [m]
-
-    xmax: float
-        Position of last node along X [m]
-
-    ymin: float
-        Position of first node along Y [m]
-
-    ymax: float
-        Position of last node along Y [m]
-
-    bc_xmin: vector of strings
-        Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_xmax: vector of strings
-        Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_ymin: vector of strings
-        Boundary condition at min Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_ymax: vector of strings
-        Boundary condition at max Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    moving_window_velocity: vector of floats, optional
-        Moving frame velocity [m/s]
-
-    refined_regions: list of lists, optional
-        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-        lo and hi being vectors of length 2 specifying the extent of the region,
-        and refinement_factor defaulting to [2,2] (relative to next lower level)
-
-    lower_bound_particles: vector of floats, optional
-        Position of particle lower bound [m]
-
-    upper_bound_particles: vector of floats, optional
-        Position of particle upper bound [m]
-
-    xmin_particles: float, optional
-        Position of min particle boundary along X [m]
-
-    xmax_particles: float, optional
-        Position of max particle boundary along X [m]
-
-    ymin_particles: float, optional
-        Position of min particle boundary along Y [m]
-
-    ymax_particles: float, optional
-        Position of max particle boundary along Y [m]
-
-    lower_boundary_conditions_particles: vector of strings, optional
-        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
-
-    upper_boundary_conditions_particles: vector of strings, optional
-        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
-
-    bc_xmin_particles: string, optional
-        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_xmax_particles: string, optional
-        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_ymin_particles: string, optional
-        Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_ymax_particles: string, optional
-        Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal
-
-    guard_cells: vector of integers, optional
-        Number of guard cells used along each direction
-
-    pml_cells: vector of integers, optional
-        Number of Perfectly Matched Layer (PML) cells along each direction
 
     References
     ----------
@@ -745,115 +821,323 @@ class PICMI_Cartesian2DGrid(_ClassWithInit):
       US Particle Accelerator School (USPAS) Summer Session, Self-Consistent Simulations of Beam and Plasma Systems
       https://people.nscl.msu.edu/~lund/uspas/scs_2016/lec_adv/A1b_EM_Waves.pdf
     """
-    # Note for implementations, as a matter of convenience and flexibility, the user interface allows
-    # specifying various quantities using either the individual named attributes (such as nx and ny) or a
-    # vector of values (such as number_of_cells). However, internally, only the vectors are saved and
-    # the implementation needs to use the those to access the user input.
+    number_of_dimensions: int = 2
 
-    number_of_dimensions = 2
+    # Vector form parameters (preferred)
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of integers. Number of cells along each axis (number of nodes is number_of_cells+1). Either this or nx and ny must be specified (not both)."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats. Position of the node at the lower bound [m]. Either this or xmin and ymin must be specified (not both)."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats. Position of the node at the upper bound [m]. Either this or xmax and ymax must be specified (not both)."
+    )
+    lower_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings. Conditions at lower boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmin and bc_ymin must be specified (not both)."
+    )
+    upper_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings. Conditions at upper boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmax and bc_ymax must be specified (not both)."
+    )
 
-    def __init__(self, number_of_cells=None, lower_bound=None, upper_bound=None,
-                 lower_boundary_conditions=None, upper_boundary_conditions=None,
-                 nx=None, ny=None,
-                 xmin=None, xmax=None, ymin=None, ymax=None,
-                 bc_xmin=None, bc_xmax=None, bc_ymin=None, bc_ymax=None,
-                 moving_window_velocity=None, refined_regions=[],lower_bound_particles=None, upper_bound_particles=None,
-                 xmin_particles=None, xmax_particles=None, ymin_particles=None, ymax_particles=None,
-                 lower_boundary_conditions_particles=None, upper_boundary_conditions_particles=None,
-                 bc_xmin_particles=None, bc_xmax_particles=None, bc_ymin_particles=None, bc_ymax_particles=None,
-                 guard_cells=None, pml_cells=None,
-                 **kw):
+    # Individual named parameters (alternative form)
+    nx: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along X (number of nodes=nx+1). Either this (along with ny) or number_of_cells must be specified (not both)."
+    )
+    ny: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along Y (number of nodes=ny+1). Either this (along with nx) or number_of_cells must be specified (not both)."
+    )
+    xmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along X [m]. Either this (along with ymin) or lower_bound must be specified (not both)."
+    )
+    xmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along X [m]. Either this (along with ymax) or upper_bound must be specified (not both)."
+    )
+    ymin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along Y [m]. Either this (along with xmin) or lower_bound must be specified (not both)."
+    )
+    ymax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along Y [m]. Either this (along with xmax) or upper_bound must be specified (not both)."
+    )
+    bc_xmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_ymin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_xmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_ymax) or upper_boundary_conditions must be specified (not both)."
+    )
+    bc_ymin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_ymax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmax) or upper_boundary_conditions must be specified (not both)."
+    )
 
-        # Sanity check and init of input arguments related to grid parameters
-        assert (number_of_cells is None) and (nx is not None and ny is not None) or \
-               (number_of_cells is not None) and (nx is None and ny is None), \
-                Exception('Either number_of_cells or nx and ny must be specified')
-        assert (lower_bound is None) and (xmin is not None and ymin is not None) or \
-               (lower_bound is not None) and (xmin is None and ymin is None), \
-                Exception('Either lower_bound or xmin and ymin must be specified')
-        assert (upper_bound is None) and (xmax is not None and ymax is not None) or \
-               (upper_bound is not None) and (xmax is None and ymax is None), \
-                Exception('Either upper_bound or xmax and ymax must be specified')
-        assert (lower_boundary_conditions is None) and (bc_xmin is not None and bc_ymin is not None) or \
-               (lower_boundary_conditions is not None) and (bc_xmin is None and bc_ymin is None), \
-                Exception('Either lower_boundary_conditions or bc_xmin and bc_ymin must be specified')
-        assert (upper_boundary_conditions is None) and (bc_xmax is not None and bc_ymax is not None) or \
-               (upper_boundary_conditions is not None) and (bc_xmax is None and bc_ymax is None), \
-                Exception('Either upper_boundary_conditions or bc_xmax and bc_ymax must be specified')
+    # Particle boundary parameters (vector form)
+    lower_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle lower bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    upper_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle upper bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    lower_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at lower boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
+    upper_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at upper boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
 
-        if number_of_cells is None:
-            number_of_cells = [nx, ny]
-        if lower_bound is None:
-            lower_bound = [xmin, ymin]
-        if upper_bound is None:
-            upper_bound = [xmax, ymax]
-        if lower_boundary_conditions is None:
-            lower_boundary_conditions = [bc_xmin, bc_ymin]
-        if upper_boundary_conditions is None:
-            upper_boundary_conditions = [bc_xmax, bc_ymax]
+    # Particle boundary parameters (individual form)
+    xmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along X [m]."
+    )
+    xmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along X [m]."
+    )
+    ymin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along Y [m]."
+    )
+    ymax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along Y [m]."
+    )
+    bc_xmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_xmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_ymin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_ymax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal."
+    )
 
-        # Sanity check and init of input arguments related to particle boundary parameters
-        # By default, if not specified, particle boundary values are the same as field boundary values
-        # By default, if not specified, particle boundary conditions are the same as field boundary conditions
-        if lower_bound_particles is None:
-            if (xmin_particles is None) and (ymin_particles is None):
-                lower_bound_particles = lower_bound
+    # Other parameters
+    moving_window_velocity: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Moving frame velocity [m/s]"
+    )
+    refined_regions: list[list] = Field(
+        default_factory=list,
+        description="List of lists, optional. List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor], with level being the refinement level (1 being first, 2 being second etc), lo and hi being vectors of length 2 specifying the extent of the region, and refinement_factor defaulting to [2,2] (relative to next lower level)."
+    )
+    guard_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of guard cells used along each direction"
+    )
+    pml_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of Perfectly Matched Layer (PML) cells along each direction"
+    )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_parameters(cls, data: Any) -> Any:
+        """Normalize individual parameters to vector form before validation"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Validate either/or constraints for grid parameters
+        number_of_cells = data.get('number_of_cells')
+        nx = data.get('nx')
+        ny = data.get('ny')
+        if (number_of_cells is None) == ((nx is not None) and (ny is not None)):
+            raise ValueError('Exactly one of number_of_cells or (nx and ny) must be specified')
+        
+        lower_bound = data.get('lower_bound')
+        xmin = data.get('xmin')
+        ymin = data.get('ymin')
+        if (lower_bound is None) == ((xmin is not None) and (ymin is not None)):
+            raise ValueError('Exactly one of lower_bound or (xmin and ymin) must be specified')
+        
+        upper_bound = data.get('upper_bound')
+        xmax = data.get('xmax')
+        ymax = data.get('ymax')
+        if (upper_bound is None) == ((xmax is not None) and (ymax is not None)):
+            raise ValueError('Exactly one of upper_bound or (xmax and ymax) must be specified')
+        
+        lower_boundary_conditions = data.get('lower_boundary_conditions')
+        bc_xmin = data.get('bc_xmin')
+        bc_ymin = data.get('bc_ymin')
+        if (lower_boundary_conditions is None) == ((bc_xmin is not None) and (bc_ymin is not None)):
+            raise ValueError('Exactly one of lower_boundary_conditions or (bc_xmin and bc_ymin) must be specified')
+        
+        upper_boundary_conditions = data.get('upper_boundary_conditions')
+        bc_xmax = data.get('bc_xmax')
+        bc_ymax = data.get('bc_ymax')
+        if (upper_boundary_conditions is None) == ((bc_xmax is not None) and (bc_ymax is not None)):
+            raise ValueError('Exactly one of upper_boundary_conditions or (bc_xmax and bc_ymax) must be specified')
+        
+        # Convert individual parameters to vectors if vectors not provided
+        if number_of_cells is None and nx is not None and ny is not None:
+            data['number_of_cells'] = [nx, ny]
+            data.pop('nx', None)
+            data.pop('ny', None)
+        elif number_of_cells is not None:
+            data.pop('nx', None)
+            data.pop('ny', None)
+        
+        if lower_bound is None and xmin is not None and ymin is not None:
+            data['lower_bound'] = [xmin, ymin]
+            data.pop('xmin', None)
+            data.pop('ymin', None)
+        elif lower_bound is not None:
+            data.pop('xmin', None)
+            data.pop('ymin', None)
+        
+        if upper_bound is None and xmax is not None and ymax is not None:
+            data['upper_bound'] = [xmax, ymax]
+            data.pop('xmax', None)
+            data.pop('ymax', None)
+        elif upper_bound is not None:
+            data.pop('xmax', None)
+            data.pop('ymax', None)
+        
+        if lower_boundary_conditions is None and bc_xmin is not None and bc_ymin is not None:
+            data['lower_boundary_conditions'] = [bc_xmin, bc_ymin]
+            data.pop('bc_xmin', None)
+            data.pop('bc_ymin', None)
+        elif lower_boundary_conditions is not None:
+            data.pop('bc_xmin', None)
+            data.pop('bc_ymin', None)
+        
+        if upper_boundary_conditions is None and bc_xmax is not None and bc_ymax is not None:
+            data['upper_boundary_conditions'] = [bc_xmax, bc_ymax]
+            data.pop('bc_xmax', None)
+            data.pop('bc_ymax', None)
+        elif upper_boundary_conditions is not None:
+            data.pop('bc_xmax', None)
+            data.pop('bc_ymax', None)
+        
+        # Handle particle boundaries
+        if data.get('lower_bound_particles') is None:
+            xmin_p = data.get('xmin_particles')
+            ymin_p = data.get('ymin_particles')
+            if xmin_p is not None or ymin_p is not None:
+                data['lower_bound_particles'] = [xmin_p, ymin_p]
+                data.pop('xmin_particles', None)
+                data.pop('ymin_particles', None)
+        if data.get('upper_bound_particles') is None:
+            xmax_p = data.get('xmax_particles')
+            ymax_p = data.get('ymax_particles')
+            if xmax_p is not None or ymax_p is not None:
+                data['upper_bound_particles'] = [xmax_p, ymax_p]
+                data.pop('xmax_particles', None)
+                data.pop('ymax_particles', None)
+        if data.get('lower_boundary_conditions_particles') is None:
+            bc_xmin_p = data.get('bc_xmin_particles')
+            bc_ymin_p = data.get('bc_ymin_particles')
+            if bc_xmin_p is not None or bc_ymin_p is not None:
+                data['lower_boundary_conditions_particles'] = [bc_xmin_p, bc_ymin_p]
+                data.pop('bc_xmin_particles', None)
+                data.pop('bc_ymin_particles', None)
+        if data.get('upper_boundary_conditions_particles') is None:
+            bc_xmax_p = data.get('bc_xmax_particles')
+            bc_ymax_p = data.get('bc_ymax_particles')
+            if bc_xmax_p is not None or bc_ymax_p is not None:
+                data['upper_boundary_conditions_particles'] = [bc_xmax_p, bc_ymax_p]
+                data.pop('bc_xmax_particles', None)
+                data.pop('bc_ymax_particles', None)
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _validate_and_normalize(self) -> Self:
+        """Validate dimensions and normalize particle boundaries"""
+        # At this point, vectors should already be set by mode='before' validator
+        # Handle particle boundaries - default to field boundaries if not specified
+        if self.lower_bound_particles is None:
+            if self.xmin_particles is None and self.ymin_particles is None:
+                self.lower_bound_particles = list(self.lower_bound)
             else:
-                lower_bound_particles = [xmin_particles, ymin_particles]
-        if upper_bound_particles is None:
-            if (xmax_particles is None) and (ymax_particles is None):
-                upper_bound_particles = upper_bound
+                self.lower_bound_particles = [self.xmin_particles, self.ymin_particles]
+                self.xmin_particles = None
+                self.ymin_particles = None
+        if self.upper_bound_particles is None:
+            if self.xmax_particles is None and self.ymax_particles is None:
+                self.upper_bound_particles = list(self.upper_bound)
             else:
-                upper_bound_particles=[xmax_particles, ymax_particles]
-
-        if lower_boundary_conditions_particles is None:
-            if (bc_xmin_particles is None) and (bc_ymin_particles is None):
-                lower_boundary_conditions_particles = lower_boundary_conditions
+                self.upper_bound_particles = [self.xmax_particles, self.ymax_particles]
+                self.xmax_particles = None
+                self.ymax_particles = None
+        if self.lower_boundary_conditions_particles is None:
+            if self.bc_xmin_particles is None and self.bc_ymin_particles is None:
+                self.lower_boundary_conditions_particles = list(self.lower_boundary_conditions)
             else:
-                lower_boundary_conditions_particles = [bc_xmin_particles, bc_ymin_particles]
-        if upper_boundary_conditions_particles is None:
-            if (bc_xmax_particles is None) and (bc_ymax_particles is None):
-                upper_boundary_conditions_particles = upper_boundary_conditions
+                self.lower_boundary_conditions_particles = [self.bc_xmin_particles, self.bc_ymin_particles]
+                self.bc_xmin_particles = None
+                self.bc_ymin_particles = None
+        if self.upper_boundary_conditions_particles is None:
+            if self.bc_xmax_particles is None and self.bc_ymax_particles is None:
+                self.upper_boundary_conditions_particles = list(self.upper_boundary_conditions)
             else:
-                upper_boundary_conditions_particles = [bc_xmax_particles, bc_ymax_particles]
-
-        # Sanity check on dimensionality of vector quantities
-        assert len(number_of_cells) == 2, Exception('Wrong number of cells specified')
-        assert len(lower_bound) == 2, Exception('Wrong number of lower bounds specified')
-        assert len(upper_bound) == 2, Exception('Wrong number of upper bounds specified')
-        assert len(lower_boundary_conditions) == 2, Exception('Wrong number of lower boundary conditions specified')
-        assert len(upper_boundary_conditions) == 2, Exception('Wrong number of upper boundary conditions specified')
-        assert len(lower_bound_particles) == 2, Exception('Wrong number of particle lower bounds specified')
-        assert len(upper_bound_particles) == 2, Exception('Wrong number of particle upper bounds specified')
-        assert len(lower_boundary_conditions_particles) == 2, Exception('Wrong number of lower particle boundary conditions specified')
-        assert len(upper_boundary_conditions_particles) == 2, Exception('Wrong number of upper particle boundary conditions specified')
-
-        self.number_of_cells = number_of_cells
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.lower_boundary_conditions = lower_boundary_conditions
-        self.upper_boundary_conditions = upper_boundary_conditions
-        self.lower_bound_particles = lower_bound_particles
-        self.upper_bound_particles = upper_bound_particles
-        self.lower_boundary_conditions_particles = lower_boundary_conditions_particles
-        self.upper_boundary_conditions_particles = upper_boundary_conditions_particles
-        self.guard_cells = guard_cells
-        self.pml_cells = pml_cells
-
-        self.moving_window_velocity = moving_window_velocity
-
-        self.refined_regions = refined_regions
-
+                self.upper_boundary_conditions_particles = [self.bc_xmax_particles, self.bc_ymax_particles]
+                self.bc_xmax_particles = None
+                self.bc_ymax_particles = None
+        
+        # Dimensions are validated by Field(min_length=2, max_length=2) constraints
+        
+        # Process refined regions
         for region in self.refined_regions:
             if len(region) == 3:
-                region.append([2,2])
-            assert len(region[1]) == 2, Exception('The lo extent of the refined region must be a vector of length 2')
-            assert len(region[2]) == 2, Exception('The hi extent of the refined region must be a vector of length 2')
-            assert len(region[3]) == 2, Exception('The refinement factor of the refined region must be a vector of length 2')
+                region.append([2, 2])
+            if len(region[1]) != 2:
+                raise ValueError('The lo extent of the refined region must be a vector of length 2')
+            if len(region[2]) != 2:
+                raise ValueError('The hi extent of the refined region must be a vector of length 2')
+            if len(region[3]) != 2:
+                raise ValueError('The refinement factor of the refined region must be a vector of length 2')
+        
+        return self
 
-        self.handle_init(kw)
-
-    def add_refined_region(self, level, lo, hi, refinement_factor=[2,2]):
+    def add_refined_region(self, level, lo, hi, refinement_factor=[2, 2]):
         """Add a refined region.
         level: the refinement level, with 1 being the first level of refinement, 2 being the second etc.
         lo, hi: vectors of length 2 specifying the extent of the region
@@ -864,134 +1148,9 @@ class PICMI_Cartesian2DGrid(_ClassWithInit):
 
 class PICMI_Cartesian3DGrid(_ClassWithInit):
     """
-    Three dimensional Cartesian grid
+    Three dimensional Cartesian grid.
     Parameters can be specified either as vectors or separately.
     (If both are specified, the vector is used.)
-
-    Parameters
-    ----------
-    number_of_cells: vector of integers
-        Number of cells along each axis (number of nodes is number_of_cells+1)
-
-    lower_bound: vector of floats
-        Position of the node at the lower bound [m]
-
-    upper_bound: vector of floats
-        Position of the node at the upper bound [m]
-
-    lower_boundary_conditions: vector of strings
-        Conditions at lower boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    upper_boundary_conditions: vector of strings
-        Conditions at upper boundaries, periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    nx: integer
-        Number of cells along X (number of nodes=nx+1)
-
-    ny: integer
-        Number of cells along Y (number of nodes=ny+1)
-
-    nz: integer
-        Number of cells along Z (number of nodes=nz+1)
-
-    xmin: float
-        Position of first node along X [m]
-
-    xmax: float
-        Position of last node along X [m]
-
-    ymin: float
-        Position of first node along Y [m]
-
-    ymax: float
-        Position of last node along Y [m]
-
-    zmin: float
-        Position of first node along Z [m]
-
-    zmax: float
-        Position of last node along Z [m]
-
-    bc_xmin: string
-        Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_xmax: string
-        Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_ymin: string
-        Boundary condition at min Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_ymax: string
-        Boundary condition at max Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_zmin: string
-        Boundary condition at min Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    bc_zmax: string
-        Boundary condition at max Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann
-
-    moving_window_velocity: vector of floats, optional
-        Moving frame velocity [m/s]
-
-    refined_regions: list of lists, optional
-        List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor],
-        with level being the refinement level, with 1 being the first level of refinement, 2 being the second etc,
-        lo and hi being vectors of length 3 specifying the extent of the region,
-        and refinement_factor defaulting to [2,2,2] (relative to next lower level)
-
-    lower_bound_particles: vector of floats, optional
-        Position of particle lower bound [m]
-
-    upper_bound_particles: vector of floats, optional
-        Position of particle upper bound [m]
-
-    xmin_particles: float, optional
-        Position of min particle boundary along X [m]
-
-    xmax_particles: float, optional
-        Position of max particle boundary along X [m]
-
-    ymin_particles: float, optional
-        Position of min particle boundary along Y [m]
-
-    ymax_particles: float, optional
-        Position of max particle boundary along Y [m]
-
-    zmin_particles float, optional
-        Position of min particle boundary along Z [m]
-
-    zmax_particles: float, optional
-        Position of max particle boundary along Z [m]
-
-    lower_boundary_conditions_particles: vector of strings, optional
-        Conditions at lower boundaries for particles, periodic, absorbing, reflect or thermal
-
-    upper_boundary_conditions_particles: vector of strings, optional
-        Conditions at upper boundaries for particles, periodic, absorbing, reflect or thermal
-
-    bc_xmin_particles: string, optional
-        Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_xmax_particles: string, optional
-        Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_ymin_particles: string, optional
-        Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_ymax_particles: string, optional
-        Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_zmin_particles: string, optional
-        Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal
-
-    bc_zmax_particles: string, optional
-        Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal
-
-    guard_cells: vector of integers, optional
-        Number of guard cells used along each direction
-
-    pml_cells: vector of integers, optional
-        Number of Perfectly Matched Layer (PML) cells along each direction
 
     References
     ----------
@@ -1006,114 +1165,386 @@ class PICMI_Cartesian3DGrid(_ClassWithInit):
       US Particle Accelerator School (USPAS) Summer Session, Self-Consistent Simulations of Beam and Plasma Systems
       https://people.nscl.msu.edu/~lund/uspas/scs_2016/lec_adv/A1b_EM_Waves.pdf
     """
-    # Note for implementations, as a matter of convenience and flexibility, the user interface allows
-    # specifying various quantities using either the individual named attributes (such as nx, ny, and nz) or a
-    # vector of values (such as number_of_cells). However, internally, only the vectors are saved and
-    # the implementation needs to use the those to access the user input.
+    number_of_dimensions: int = 3
 
-    number_of_dimensions = 3
+    # Vector form parameters (preferred)
+    number_of_cells: Sequence[int] | None = Field(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Vector of integers. Number of cells along each axis (number of nodes is number_of_cells+1). Either this or nx, ny, and nz must be specified (not both)."
+    )
+    lower_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Vector of floats. Position of the node at the lower bound [m]. Either this or xmin, ymin, and zmin must be specified (not both)."
+    )
+    upper_bound: Sequence[float] | None = Field(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Vector of floats. Position of the node at the upper bound [m]. Either this or xmax, ymax, and zmax must be specified (not both)."
+    )
+    lower_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Vector of strings. Conditions at lower boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmin, bc_ymin, and bc_zmin must be specified (not both)."
+    )
+    upper_boundary_conditions: Sequence[str] | None = Field(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="Vector of strings. Conditions at upper boundaries: periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this or bc_xmax, bc_ymax, and bc_zmax must be specified (not both)."
+    )
 
-    def __init__(self, number_of_cells=None, lower_bound=None, upper_bound=None,
-                 lower_boundary_conditions=None, upper_boundary_conditions=None,
-                 nx=None, ny=None, nz=None,
-                 xmin=None, xmax=None, ymin=None, ymax=None, zmin=None, zmax=None,
-                 bc_xmin=None, bc_xmax=None, bc_ymin=None, bc_ymax=None, bc_zmin=None, bc_zmax=None,
-                 moving_window_velocity=None, refined_regions=[], lower_bound_particles=None, upper_bound_particles=None,
-                 xmin_particles=None, xmax_particles=None, ymin_particles=None, ymax_particles=None, zmin_particles=None, zmax_particles=None,
-                 lower_boundary_conditions_particles=None, upper_boundary_conditions_particles=None,
-                 bc_xmin_particles=None, bc_xmax_particles=None, bc_ymin_particles=None, bc_ymax_particles=None,
-                 bc_zmin_particles=None, bc_zmax_particles=None, guard_cells=None, pml_cells=None,
-                 **kw):
+    # Individual named parameters (alternative form)
+    nx: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along X (number of nodes=nx+1). Either this (along with ny and nz) or number_of_cells must be specified (not both)."
+    )
+    ny: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along Y (number of nodes=ny+1). Either this (along with nx and nz) or number_of_cells must be specified (not both)."
+    )
+    nz: int | None = Field(
+        default=None,
+        description="Integer. Number of cells along Z (number of nodes=nz+1). Either this (along with nx and ny) or number_of_cells must be specified (not both)."
+    )
+    xmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along X [m]. Either this (along with ymin and zmin) or lower_bound must be specified (not both)."
+    )
+    xmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along X [m]. Either this (along with ymax and zmax) or upper_bound must be specified (not both)."
+    )
+    ymin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along Y [m]. Either this (along with xmin and zmin) or lower_bound must be specified (not both)."
+    )
+    ymax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along Y [m]. Either this (along with xmax and zmax) or upper_bound must be specified (not both)."
+    )
+    zmin: float | None = Field(
+        default=None,
+        description="Float. Position of first node along Z [m]. Either this (along with xmin and ymin) or lower_bound must be specified (not both)."
+    )
+    zmax: float | None = Field(
+        default=None,
+        description="Float. Position of last node along Z [m]. Either this (along with xmax and ymax) or upper_bound must be specified (not both)."
+    )
+    bc_xmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_ymin and bc_zmin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_xmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max X: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_ymax and bc_zmax) or upper_boundary_conditions must be specified (not both)."
+    )
+    bc_ymin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmin and bc_zmin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_ymax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max Y: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmax and bc_zmax) or upper_boundary_conditions must be specified (not both)."
+    )
+    bc_zmin: str | None = Field(
+        default=None,
+        description="String. Boundary condition at min Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmin and bc_ymin) or lower_boundary_conditions must be specified (not both)."
+    )
+    bc_zmax: str | None = Field(
+        default=None,
+        description="String. Boundary condition at max Z: One of periodic, open, dirichlet, absorbing_silver_mueller, or neumann. Either this (along with bc_xmax and bc_ymax) or upper_boundary_conditions must be specified (not both)."
+    )
 
-        # Sanity check and init of input arguments related to grid parameters
-        assert (number_of_cells is None) and (nx is not None and ny is not None and nz is not None) or \
-               (number_of_cells is not None) and (nx is None and ny is None and nz is None), \
-                Exception('Either number_of_cells or nx, ny, and nz must be specified')
-        assert (lower_bound is None) and (xmin is not None and ymin is not None and zmin is not None) or \
-               (lower_bound is not None) and (xmin is None and ymin is None and zmin is None), \
-                Exception('Either lower_bound or xmin, ymin, and zmin must be specified')
-        assert (upper_bound is None) and (xmax is not None and ymax is not None and zmax is not None) or \
-               (upper_bound is not None) and (xmax is None and ymax is None and zmax is None), \
-                Exception('Either upper_bound or xmax, ymax, and zmax must be specified')
-        assert (lower_boundary_conditions is None) and (bc_xmin is not None and bc_ymin is not None and bc_zmin is not None) or \
-               (lower_boundary_conditions is not None) and (bc_xmin is None and bc_ymin is None and bc_zmin is None), \
-                Exception('Either lower_boundary_conditions or bc_xmin, bc_ymin, and bc_zmin must be specified')
-        assert (upper_boundary_conditions is None) and (bc_xmax is not None and bc_ymax is not None and bc_zmax is not None) or \
-               (upper_boundary_conditions is not None) and (bc_xmax is None and bc_ymax is None and bc_zmax is None), \
-                Exception('Either upper_boundary_conditions or bc_xmax, bc_ymax, and bc_zmax must be specified')
+    # Particle boundary parameters (vector form)
+    lower_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle lower bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    upper_bound_particles: Sequence[float] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of floats, optional. Position of particle upper bound [m]. By default, if not specified, particle boundary values are the same as field boundary values."
+    )
+    lower_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at lower boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
+    upper_boundary_conditions_particles: Sequence[str] | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Vector of strings, optional. Conditions at upper boundaries for particles: periodic, absorbing, reflect or thermal. By default, if not specified, particle boundary conditions are the same as field boundary conditions."
+    )
 
-        if number_of_cells is None:
-            number_of_cells = [nx, ny, nz]
-        if lower_bound is None:
-            lower_bound = [xmin, ymin, zmin]
-        if upper_bound is None:
-            upper_bound = [xmax, ymax, zmax]
-        if lower_boundary_conditions is None:
-            lower_boundary_conditions = [bc_xmin, bc_ymin, bc_zmin]
-        if upper_boundary_conditions is None:
-            upper_boundary_conditions = [bc_xmax, bc_ymax, bc_zmax]
+    # Particle boundary parameters (individual form)
+    xmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along X [m]."
+    )
+    xmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along X [m]."
+    )
+    ymin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along Y [m]."
+    )
+    ymax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along Y [m]."
+    )
+    zmin_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of min particle boundary along Z [m]."
+    )
+    zmax_particles: float | None = Field(
+        default=None,
+        description="Float, optional. Position of max particle boundary along Z [m]."
+    )
+    bc_xmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min X for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_xmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max X for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_ymin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min Y for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_ymax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max Y for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_zmin_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at min Z for particles: One of periodic, absorbing, reflect, thermal."
+    )
+    bc_zmax_particles: str | None = Field(
+        default=None,
+        description="String, optional. Boundary condition at max Z for particles: One of periodic, absorbing, reflect, thermal."
+    )
 
-        # Sanity check and init of input arguments related to particle boundary parameters
-        # By default, if not specified, particle boundary values are the same as field boundary values
-        # By default, if not specified, particle boundary conditions are the same as field boundary conditions
-        if lower_bound_particles is None:
-            if (xmin_particles is None) and (ymin_particles is None) and (zmin_particles is None):
-                lower_bound_particles = lower_bound
+    # Other parameters
+    moving_window_velocity: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Moving frame velocity [m/s]"
+    )
+    refined_regions: list[list] = Field(
+        default_factory=list,
+        description="List of lists, optional. List of refined regions, each element being a list of the format [level, lo, hi, refinement_factor], with level being the refinement level (1 being first, 2 being second etc), lo and hi being vectors of length 3 specifying the extent of the region, and refinement_factor defaulting to [2,2,2] (relative to next lower level)."
+    )
+    guard_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of guard cells used along each direction"
+    )
+    pml_cells: Sequence[int] | None = Field(
+        default=None,
+        description="Vector of integers, optional. Number of Perfectly Matched Layer (PML) cells along each direction"
+    )
+
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_parameters(cls, data: Any) -> Any:
+        """Normalize individual parameters to vector form before validation"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Validate either/or constraints for grid parameters
+        number_of_cells = data.get('number_of_cells')
+        nx = data.get('nx')
+        ny = data.get('ny')
+        nz = data.get('nz')
+        if (number_of_cells is None) == ((nx is not None) and (ny is not None) and (nz is not None)):
+            raise ValueError('Exactly one of number_of_cells or (nx, ny, and nz) must be specified')
+        
+        lower_bound = data.get('lower_bound')
+        xmin = data.get('xmin')
+        ymin = data.get('ymin')
+        zmin = data.get('zmin')
+        if (lower_bound is None) == ((xmin is not None) and (ymin is not None) and (zmin is not None)):
+            raise ValueError('Exactly one of lower_bound or (xmin, ymin, and zmin) must be specified')
+        
+        upper_bound = data.get('upper_bound')
+        xmax = data.get('xmax')
+        ymax = data.get('ymax')
+        zmax = data.get('zmax')
+        if (upper_bound is None) == ((xmax is not None) and (ymax is not None) and (zmax is not None)):
+            raise ValueError('Exactly one of upper_bound or (xmax, ymax, and zmax) must be specified')
+        
+        lower_boundary_conditions = data.get('lower_boundary_conditions')
+        bc_xmin = data.get('bc_xmin')
+        bc_ymin = data.get('bc_ymin')
+        bc_zmin = data.get('bc_zmin')
+        if (lower_boundary_conditions is None) == ((bc_xmin is not None) and (bc_ymin is not None) and (bc_zmin is not None)):
+            raise ValueError('Exactly one of lower_boundary_conditions or (bc_xmin, bc_ymin, and bc_zmin) must be specified')
+        
+        upper_boundary_conditions = data.get('upper_boundary_conditions')
+        bc_xmax = data.get('bc_xmax')
+        bc_ymax = data.get('bc_ymax')
+        bc_zmax = data.get('bc_zmax')
+        if (upper_boundary_conditions is None) == ((bc_xmax is not None) and (bc_ymax is not None) and (bc_zmax is not None)):
+            raise ValueError('Exactly one of upper_boundary_conditions or (bc_xmax, bc_ymax, and bc_zmax) must be specified')
+        
+        # Convert individual parameters to vectors if vectors not provided
+        if number_of_cells is None and nx is not None and ny is not None and nz is not None:
+            data['number_of_cells'] = [nx, ny, nz]
+            data.pop('nx', None)
+            data.pop('ny', None)
+            data.pop('nz', None)
+        elif number_of_cells is not None:
+            data.pop('nx', None)
+            data.pop('ny', None)
+            data.pop('nz', None)
+        
+        if lower_bound is None and xmin is not None and ymin is not None and zmin is not None:
+            data['lower_bound'] = [xmin, ymin, zmin]
+            data.pop('xmin', None)
+            data.pop('ymin', None)
+            data.pop('zmin', None)
+        elif lower_bound is not None:
+            data.pop('xmin', None)
+            data.pop('ymin', None)
+            data.pop('zmin', None)
+        
+        if upper_bound is None and xmax is not None and ymax is not None and zmax is not None:
+            data['upper_bound'] = [xmax, ymax, zmax]
+            data.pop('xmax', None)
+            data.pop('ymax', None)
+            data.pop('zmax', None)
+        elif upper_bound is not None:
+            data.pop('xmax', None)
+            data.pop('ymax', None)
+            data.pop('zmax', None)
+        
+        if lower_boundary_conditions is None and bc_xmin is not None and bc_ymin is not None and bc_zmin is not None:
+            data['lower_boundary_conditions'] = [bc_xmin, bc_ymin, bc_zmin]
+            data.pop('bc_xmin', None)
+            data.pop('bc_ymin', None)
+            data.pop('bc_zmin', None)
+        elif lower_boundary_conditions is not None:
+            data.pop('bc_xmin', None)
+            data.pop('bc_ymin', None)
+            data.pop('bc_zmin', None)
+        
+        if upper_boundary_conditions is None and bc_xmax is not None and bc_ymax is not None and bc_zmax is not None:
+            data['upper_boundary_conditions'] = [bc_xmax, bc_ymax, bc_zmax]
+            data.pop('bc_xmax', None)
+            data.pop('bc_ymax', None)
+            data.pop('bc_zmax', None)
+        elif upper_boundary_conditions is not None:
+            data.pop('bc_xmax', None)
+            data.pop('bc_ymax', None)
+            data.pop('bc_zmax', None)
+        
+        # Handle particle boundaries
+        if data.get('lower_bound_particles') is None:
+            xmin_p = data.get('xmin_particles')
+            ymin_p = data.get('ymin_particles')
+            zmin_p = data.get('zmin_particles')
+            if xmin_p is not None or ymin_p is not None or zmin_p is not None:
+                data['lower_bound_particles'] = [xmin_p, ymin_p, zmin_p]
+                data.pop('xmin_particles', None)
+                data.pop('ymin_particles', None)
+                data.pop('zmin_particles', None)
+        if data.get('upper_bound_particles') is None:
+            xmax_p = data.get('xmax_particles')
+            ymax_p = data.get('ymax_particles')
+            zmax_p = data.get('zmax_particles')
+            if xmax_p is not None or ymax_p is not None or zmax_p is not None:
+                data['upper_bound_particles'] = [xmax_p, ymax_p, zmax_p]
+                data.pop('xmax_particles', None)
+                data.pop('ymax_particles', None)
+                data.pop('zmax_particles', None)
+        if data.get('lower_boundary_conditions_particles') is None:
+            bc_xmin_p = data.get('bc_xmin_particles')
+            bc_ymin_p = data.get('bc_ymin_particles')
+            bc_zmin_p = data.get('bc_zmin_particles')
+            if bc_xmin_p is not None or bc_ymin_p is not None or bc_zmin_p is not None:
+                data['lower_boundary_conditions_particles'] = [bc_xmin_p, bc_ymin_p, bc_zmin_p]
+                data.pop('bc_xmin_particles', None)
+                data.pop('bc_ymin_particles', None)
+                data.pop('bc_zmin_particles', None)
+        if data.get('upper_boundary_conditions_particles') is None:
+            bc_xmax_p = data.get('bc_xmax_particles')
+            bc_ymax_p = data.get('bc_ymax_particles')
+            bc_zmax_p = data.get('bc_zmax_particles')
+            if bc_xmax_p is not None or bc_ymax_p is not None or bc_zmax_p is not None:
+                data['upper_boundary_conditions_particles'] = [bc_xmax_p, bc_ymax_p, bc_zmax_p]
+                data.pop('bc_xmax_particles', None)
+                data.pop('bc_ymax_particles', None)
+                data.pop('bc_zmax_particles', None)
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _validate_and_normalize(self) -> Self:
+        """Validate dimensions and normalize particle boundaries"""
+        # At this point, vectors should already be set by mode='before' validator
+        # Handle particle boundaries - default to field boundaries if not specified
+        if self.lower_bound_particles is None:
+            if self.xmin_particles is None and self.ymin_particles is None and self.zmin_particles is None:
+                self.lower_bound_particles = list(self.lower_bound)
             else:
-                lower_bound_particles = [xmin_particles, ymin_particles, zmin_particles]
-        if upper_bound_particles is None:
-            if (xmax_particles is None) and (ymax_particles is None) and (zmax_particles is None):
-                upper_bound_particles = upper_bound
+                self.lower_bound_particles = [self.xmin_particles, self.ymin_particles, self.zmin_particles]
+                self.xmin_particles = None
+                self.ymin_particles = None
+                self.zmin_particles = None
+        if self.upper_bound_particles is None:
+            if self.xmax_particles is None and self.ymax_particles is None and self.zmax_particles is None:
+                self.upper_bound_particles = list(self.upper_bound)
             else:
-                upper_bound_particles = [xmax_particles, ymax_particles, zmax_particles]
-
-        if lower_boundary_conditions_particles is None:
-            if (bc_xmin_particles is None) and (bc_ymin_particles is None) and (bc_zmin_particles is None):
-                lower_boundary_conditions_particles = lower_boundary_conditions
+                self.upper_bound_particles = [self.xmax_particles, self.ymax_particles, self.zmax_particles]
+                self.xmax_particles = None
+                self.ymax_particles = None
+                self.zmax_particles = None
+        if self.lower_boundary_conditions_particles is None:
+            if self.bc_xmin_particles is None and self.bc_ymin_particles is None and self.bc_zmin_particles is None:
+                self.lower_boundary_conditions_particles = list(self.lower_boundary_conditions)
             else:
-                lower_boundary_conditions_particles = [bc_xmin_particles, bc_ymin_particles, bc_zmin_particles]
-        if upper_boundary_conditions_particles is None:
-            if (bc_xmax_particles is None) and (bc_ymax_particles is None) and (bc_zmax_particles is None):
-                upper_boundary_conditions_particles = upper_boundary_conditions
+                self.lower_boundary_conditions_particles = [self.bc_xmin_particles, self.bc_ymin_particles, self.bc_zmin_particles]
+                self.bc_xmin_particles = None
+                self.bc_ymin_particles = None
+                self.bc_zmin_particles = None
+        if self.upper_boundary_conditions_particles is None:
+            if self.bc_xmax_particles is None and self.bc_ymax_particles is None and self.bc_zmax_particles is None:
+                self.upper_boundary_conditions_particles = list(self.upper_boundary_conditions)
             else:
-                upper_boundary_conditions_particles = [bc_xmax_particles, bc_ymax_particles, bc_zmax_particles]
-
-        # Sanity check on number of arguments of vector quantities
-        assert len(number_of_cells) == 3, Exception('Wrong number of cells specified')
-        assert len(lower_bound) == 3, Exception('Wrong number of lower bounds specified')
-        assert len(upper_bound) == 3, Exception('Wrong number of upper bounds specified')
-        assert len(lower_boundary_conditions) == 3, Exception('Wrong number of lower boundary conditions specified')
-        assert len(upper_boundary_conditions) == 3, Exception('Wrong number of upper boundary conditions specified')
-        assert len(lower_bound_particles) == 3, Exception('Wrong number of particle lower bounds specified')
-        assert len(upper_bound_particles) == 3, Exception('Wrong number of particle upper bounds specified')
-        assert len(lower_boundary_conditions_particles) == 3, Exception('Wrong number of particle lower boundary conditions specified')
-        assert len(upper_boundary_conditions_particles) == 3, Exception('Wrong number of particle upper boundary conditions specified')
-
-        self.number_of_cells = number_of_cells
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.lower_boundary_conditions = lower_boundary_conditions
-        self.upper_boundary_conditions = upper_boundary_conditions
-        self.lower_bound_particles = lower_bound_particles
-        self.upper_bound_particles = upper_bound_particles
-        self.lower_boundary_conditions_particles = lower_boundary_conditions_particles
-        self.upper_boundary_conditions_particles = upper_boundary_conditions_particles
-        self.guard_cells = guard_cells
-        self.pml_cells = pml_cells
-
-        self.moving_window_velocity = moving_window_velocity
-
-        self.refined_regions = refined_regions
+                self.upper_boundary_conditions_particles = [self.bc_xmax_particles, self.bc_ymax_particles, self.bc_zmax_particles]
+                self.bc_xmax_particles = None
+                self.bc_ymax_particles = None
+                self.bc_zmax_particles = None
+        
+        # Dimensions are validated by Field(min_length=3, max_length=3) constraints
+        
+        # Process refined regions
         for region in self.refined_regions:
             if len(region) == 3:
-                region.append([2,2,2])
-            assert len(region[1]) == 3, Exception('The lo extent of the refined region must be a vector of length 3')
-            assert len(region[2]) == 3, Exception('The hi extent of the refined region must be a vector of length 3')
-            assert len(region[3]) == 3, Exception('The refinement factor of the refined region must be a vector of length 3')
+                region.append([2, 2, 2])
+            if len(region[1]) != 3:
+                raise ValueError('The lo extent of the refined region must be a vector of length 3')
+            if len(region[2]) != 3:
+                raise ValueError('The hi extent of the refined region must be a vector of length 3')
+            if len(region[3]) != 3:
+                raise ValueError('The refinement factor of the refined region must be a vector of length 3')
+        
+        return self
 
-        self.handle_init(kw)
-
-    def add_refined_region(self, level, lo, hi, refinement_factor=[2,2,2]):
+    def add_refined_region(self, level, lo, hi, refinement_factor=[2, 2, 2]):
         """Add a refined region.
 
         Parameters

--- a/PICMI_Python/interactions.py
+++ b/PICMI_Python/interactions.py
@@ -2,28 +2,22 @@
 These should be the base classes for Python implementation of the PICMI standard
 The classes in this file are related to interactions (e.g. field ionization, collisions, QED)
 """
+from __future__ import annotations
+from typing import Any
+
+from pydantic import Field
 
 from .base import _ClassWithInit
 
+from .particles import PICMI_Species, PICMI_MultiSpecies
+
+PICMI_SpeciesType = PICMI_Species | PICMI_MultiSpecies
+
 class PICMI_FieldIonization(_ClassWithInit):
     """
-    Field ionization on an ion species
-
-    Parameters
-    ----------
-    model: string
-        Ionization model, e.g. "ADK"
-
-    ionized_species: species instance
-        Species that is ionized
-
-    product_species: species instance
-        Species in which ionized electrons are stored.
+    Field ionization on an ion species.
     """
-    def __init__(self, model, ionized_species, product_species, **kw):
-        self.model = model
-        self.ionized_species = ionized_species
-        self.product_species = product_species
-
-        self.handle_init(kw)
+    model: str = Field(description="Ionization model, e.g. 'ADK'")
+    ionized_species: "PICMI_Species | PICMI_MultiSpecies" = Field(description="Species that is ionized")
+    product_species: "PICMI_Species | PICMI_MultiSpecies" = Field(description="Species in which ionized electrons are stored")
 

--- a/PICMI_Python/lasers.py
+++ b/PICMI_Python/lasers.py
@@ -1,9 +1,21 @@
 """Classes following the PICMI standard
 These should be the base classes for Python implementation of the PICMI standard
 """
-import math
+from __future__ import annotations
 import sys
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from collections.abc import Sequence
+
+import math
 import re
+
+from pydantic import Field, model_validator
 
 from .base import _ClassWithInit, _get_constants
 
@@ -12,18 +24,18 @@ from .base import _ClassWithInit, _get_constants
 # ---------------
 
 class PICMI_GaussianLaser(_ClassWithInit):
-    """
+    r"""
     Specifies a Gaussian laser distribution.
 
     More precisely, the electric field **near the focal plane** is given by:
 
     .. math::
 
-        E(\\boldsymbol{x},t) = a_0\\times E_0\,
-        \exp\left( -\\frac{r^2}{w_0^2} - \\frac{(z-z_0-ct)^2}{c^2\\tau^2} \\right)
+        E(\boldsymbol{x},t) = a_0\times E_0\,
+        \exp\left( -\frac{r^2}{w_0^2} - \frac{(z-z_0-ct)^2}{c^2\tau^2} \right)
         \cos[ k_0( z - z_0 - ct ) - \phi_{cep} ]
 
-    where :math:`k_0 = 2\pi/\\lambda_0` is the wavevector and where
+    where :math:`k_0 = 2\pi/\lambda_0` is the wavevector and where
     :math:`E_0 = m_e c^2 k_0 / q_e` is the field amplitude for :math:`a_0=1`.
 
     .. note::
@@ -32,179 +44,137 @@ class PICMI_GaussianLaser(_ClassWithInit):
         (Gouy phase, wavefront curvature, ...) are not included in the above
         formula for simplicity, but are of course taken into account by
         the code, when initializing the laser pulse away from the focal plane.
-
-    Parameters
-    ----------
-    wavelength: float
-        Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula
-
-    waist: float
-        Waist of the Gaussian pulse at focus [m], defined as :math:`w_0` in the above formula
-
-    duration: float
-        Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula
-
-    propagation_direction: unit vector of length 3 of floats
-        Direction of propagation [1]
-
-    polarization_direction: unit vector of length 3 of floats
-        Direction of polarization [1]
-
-    focal_position: vector of length 3 of floats
-        Position of the laser focus [m]
-
-    centroid_position: vector of length 3 of floats
-        Position of the laser centroid at time 0 [m]
-
-    a0: float
-        Normalized vector potential at focus
-        Specify either a0 or E0 (E0 takes precedence).
-
-    E0: float
-        Maximum amplitude of the laser field [V/m]
-        Specify either a0 or E0 (E0 takes precedence).
-
-    phi0: float
-        Carrier envelope phase (CEP) [rad]
-
-    zeta: float
-        Spatial chirp at focus (in the lab frame) [m.s]
-
-    beta: float
-        Angular dispersion at focus (in the lab frame) [rad.s]
-
-    phi2: float
-        Temporal chirp at focus (in the lab frame) [s^2]
-
-    fill_in: bool, default=True
-        Flags whether to fill in the empty spaced opened up when the grid moves
-
-    name: string, optional
-        Optional name of the laser
     """
-    def __init__(self, wavelength, waist, duration,
-                 propagation_direction,
-                 polarization_direction,
-                 focal_position,
-                 centroid_position,
-                 a0 = None,
-                 E0 = None,
-                 phi0 = None,
-                 zeta = None,
-                 beta = None,
-                 phi2 = None,
-                 name = None,
-                 fill_in = True,
-                 **kw):
-
-        assert E0 is not None or a0 is not None, 'One of E0 or a0 must be speficied'
-
-        k0 = 2.*math.pi/wavelength
-        if E0 is None:
-            E0 = a0*_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e
-        if a0 is None:
-            a0 = E0/(_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e)
-
-        self.wavelength = wavelength
+    wavelength: float = Field(
+        description="Laser wavelength [m], defined as :math:`\\lambda_0` in the above formula"
+    )
+    waist: float = Field(
+        description="Waist of the Gaussian pulse at focus [m], defined as :math:`w_0` in the above formula"
+    )
+    duration: float = Field(
+        description="Duration of the Gaussian pulse [s], defined as :math:`\\tau` in the above formula"
+    )
+    propagation_direction: Sequence[float] = Field(
+        description="Unit vector of length 3. Direction of propagation [1]"
+    )
+    polarization_direction: Sequence[float] = Field(
+        description="Unit vector of length 3. Direction of polarization [1]"
+    )
+    focal_position: Sequence[float] = Field(
+        description="Vector of length 3 of floats. Position of the laser focus [m]"
+    )
+    centroid_position: Sequence[float] = Field(
+        description="Vector of length 3 of floats. Position of the laser centroid at time 0 [m]"
+    )
+    a0: float | None = Field(
+        default=None,
+        description="Normalized vector potential at focus. Specify either a0 or E0 (E0 takes precedence)."
+    )
+    E0: float | None = Field(
+        default=None,
+        description="Maximum amplitude of the laser field [V/m]. Specify either a0 or E0 (E0 takes precedence)."
+    )
+    phi0: float | None = Field(
+        default=None,
+        description="Carrier envelope phase (CEP) [rad]"
+    )
+    zeta: float | None = Field(
+        default=None,
+        description="Spatial chirp at focus (in the lab frame) [m.s]"
+    )
+    beta: float | None = Field(
+        default=None,
+        description="Angular dispersion at focus (in the lab frame) [rad.s]"
+    )
+    phi2: float | None = Field(
+        default=None,
+        description="Temporal chirp at focus (in the lab frame) [s^2]"
+    )
+    name: str | None = Field(
+        default=None,
+        description="Optional name of the laser"
+    )
+    fill_in: bool = Field(default=True, description="Flags whether to fill in the empty spaced opened up when the grid moves")
+    k0: float = Field(default=0.0, exclude=True, init_var=False)
+    
+    @model_validator(mode='after')
+    def _compute_a0_e0(self) -> Self:
+        """Compute a0 and E0 from each other if needed"""
+        if self.E0 is None and self.a0 is None:
+            raise ValueError('One of E0 or a0 must be specified')
+        
+        k0 = 2.*math.pi/self.wavelength
         self.k0 = k0
-        self.waist = waist
-        self.duration = duration
-        self.focal_position = focal_position
-        self.centroid_position = centroid_position
-        self.propagation_direction = propagation_direction
-        self.polarization_direction = polarization_direction
-        self.a0 = a0
-        self.E0 = E0
-        self.phi0 = phi0
-        self.zeta = zeta
-        self.beta = beta
-        self.phi2 = phi2
-        self.name = name
-        self.fill_in = fill_in
-
-        self.handle_init(kw)
+        
+        constants = _get_constants()
+        if self.E0 is None:
+            self.E0 = self.a0 * constants.m_e * constants.c**2 * k0 / constants.q_e
+        if self.a0 is None:
+            self.a0 = self.E0 / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+        
+        return self
 
 
 class PICMI_AnalyticLaser(_ClassWithInit):
     """
-    Specifies a laser with an analytically described distribution
-
-    Parameters
-    ----------
-    name=None: string, optional
-        Optional name of the laser
-
-    field_expression: string
-        Analytic expression describing the electric field of the laser [V/m]
-        Expression should be in terms of the position, 'X', 'Y', in the plane orthogonal
-        to the propagation direction, and 't' the time. The expression should describe
-        the full field, including the oscillitory component.
-        Parameters can be used in the expression with the values given as keyword arguments.
-
-    wavelength: float
-        Laser wavelength.
-        This should be built into the expression, but some codes require a specified value for numerical purposes.
-
-    propagation_direction: unit vector of length 3 of floats
-        Direction of propagation [1]
-
-    polarization_direction: unit vector of length 3 of floats
-        Direction of polarization [1]
-
-    amax: float, optional
-        Maximum normalized vector potential.
-        Specify either amax or Emax (Emax takes precedence).
-        This should be built into the expression, but some codes require a specified value for numerical purposes.
-
-    Emax: float, optional
-        Maximum amplitude of the laser field [V/m].
-        Specify either amax or Emax (Emax takes precedence).
-        This should be built into the expression, but some codes require a specified value for numerical purposes.
-
-    fill_in: bool, default=True
-        Flags whether to fill in the empty spaced opened up when the grid moves
+    Specifies a laser with an analytically described distribution.
     """
-    def __init__(self, field_expression,
-                 wavelength,
-                 propagation_direction,
-                 polarization_direction,
-                 amax = None,
-                 Emax = None,
-                 name = None,
-                 fill_in = True,
-                 **kw):
-
-        assert Emax is not None or amax is not None, 'One of Emax or amax must be speficied'
-
-        k0 = 2.*math.pi/wavelength
-        if Emax is None:
-            Emax = amax*_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e
-        if amax is None:
-            amax = Emax/(_get_constants().m_e*_get_constants().c**2*k0/_get_constants().q_e)
-
-        self.wavelength = wavelength
-        self.field_expression = field_expression
+    field_expression: str = Field(
+        description="Analytic expression describing the electric field of the laser [V/m]. Expression should be in terms of the position, 'X', 'Y', in the plane orthogonal to the propagation direction, and 't' the time. The expression should describe the full field, including the oscillitory component. Parameters can be used in the expression with the values given as keyword arguments."
+    )
+    wavelength: float = Field(
+        description="Laser wavelength. This should be built into the expression, but some codes require a specified value for numerical purposes."
+    )
+    propagation_direction: Sequence[float] = Field(
+        description="Unit vector of length 3 of floats. Direction of propagation [1]"
+    )
+    polarization_direction: Sequence[float] = Field(
+        description="Unit vector of length 3 of floats. Direction of polarization [1]"
+    )
+    amax: float | None = Field(
+        default=None,
+        description="Maximum normalized vector potential. Specify either amax or Emax (Emax takes precedence). This should be built into the expression, but some codes require a specified value for numerical purposes."
+    )
+    Emax: float | None = Field(
+        default=None,
+        description="Maximum amplitude of the laser field [V/m]. Specify either amax or Emax (Emax takes precedence). This should be built into the expression, but some codes require a specified value for numerical purposes."
+    )
+    name: str | None = Field(
+        default=None,
+        description="Optional name of the laser"
+    )
+    fill_in: bool = Field(
+        default=True,
+        description="Flags whether to fill in the empty spaced opened up when the grid moves"
+    )
+    k0: float = Field(default=0.0, exclude=True, init_var=False)
+    user_defined_kw: dict[str, Any] = Field(default_factory=dict, exclude=True, repr=False)
+    
+    @model_validator(mode='after')
+    def _compute_amax_emax(self) -> Self:
+        """Compute amax and Emax from each other if needed, and extract user-defined keywords"""
+        if self.Emax is None and self.amax is None:
+            raise ValueError('One of Emax or amax must be specified')
+        
+        # Normalize field expression
+        self.field_expression = str(self.field_expression).replace('\n', '')
+        
+        k0 = 2.*math.pi/self.wavelength
         self.k0 = k0
-        self.propagation_direction = propagation_direction
-        self.polarization_direction = polarization_direction
-        self.amax = amax
-        self.Emax = Emax
-        self.name = name
-        self.fill_in = fill_in
-
-        self.field_expression = '{}'.format(field_expression).replace('\n', '')
-
-        # --- Find any user defined keywords in the kw dictionary.
-        # --- Save them and delete them from kw.
-        # --- It's up to the code to make sure that all parameters
-        # --- used in the expression are defined.
-        self.user_defined_kw = {}
-        for k in list(kw.keys()):
-            if re.search(r'\b%s\b'%k, self.field_expression):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-
-        self.handle_init(kw)
+        
+        constants = _get_constants()
+        if self.Emax is None:
+            self.Emax = self.amax * constants.m_e * constants.c**2 * k0 / constants.q_e
+        if self.amax is None:
+            self.amax = self.Emax / (constants.m_e * constants.c**2 * k0 / constants.q_e)
+        
+        # Extract user-defined keywords from extra fields
+        if self.model_extra:
+            for k in list(self.model_extra.keys()):
+                if re.search(rf'\b{k}\b', self.field_expression):
+                    self.user_defined_kw[k] = self.model_extra.pop(k)
+        
+        return self
 
 
 # ------------------
@@ -214,20 +184,12 @@ class PICMI_AnalyticLaser(_ClassWithInit):
 
 class PICMI_LaserAntenna(_ClassWithInit):
     """
-    Specifies the laser antenna injection method
-
-    Parameters
-    ----------
-    position: vector of strings
-        Position of antenna launching the laser [m]
-
-    normal_vector: vector of strings, optional
-        Vector normal to antenna plane, defaults to the laser direction
-        of propagation [1]
+    Specifies the laser antenna injection method.
     """
-    def __init__(self, position, normal_vector=None, **kw):
-
-        self.position = position
-        self.normal_vector = normal_vector
-
-        self.handle_init(kw)
+    position: Sequence[float] = Field(
+        description="Vector of floats. Position of antenna launching the laser [m]"
+    )
+    normal_vector: Sequence[float] | None = Field(
+        default=None,
+        description="Vector of floats, optional. Vector normal to antenna plane, defaults to the laser direction of propagation [1]"
+    )

--- a/PICMI_Python/particles.py
+++ b/PICMI_Python/particles.py
@@ -3,11 +3,39 @@ These should be the base classes for Python implementation of the PICMI standard
 The classes in the file are all particle related
 """
 import math
-import sys
 import re
+import sys
 import numpy as np
+from typing import Any, Literal
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
+from collections.abc import Sequence
+
+from pydantic import Field, field_validator, model_validator
 
 from .base import _ClassWithInit
+
+from .fields import (
+    PICMI_Cartesian1DGrid,
+    PICMI_Cartesian2DGrid,
+    PICMI_Cartesian3DGrid,
+    PICMI_CylindricalGrid,
+)
+
+# Type aliases using Python 3.10+ union syntax
+PICMI_Grid = (
+    PICMI_Cartesian1DGrid
+    | PICMI_Cartesian2DGrid
+    | PICMI_Cartesian3DGrid
+    | PICMI_CylindricalGrid
+)
+# PICMI_Distribution will be defined at end of file after all distribution classes
+# PICMI_Interaction uses forward reference to avoid circular import with interactions.py
+PICMI_Interaction = "PICMI_FieldIonization"
 
 # ---------------
 # Physics objects
@@ -20,155 +48,168 @@ class PICMI_Species(_ClassWithInit):
     The species charge and mass can be specified by setting the particle type or by setting them directly.
     If the particle type is specified, the charge or mass can be set to override the value from the type.
 
-    Parameters
-    ----------
-    particle_type: string, optional
-        A string specifying an elementary particle, atom, or other, as defined in
-        the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
-
-    name: string, optional
-        Name of the species
-
-    method: {'Boris', 'Vay', 'Higuera-Cary', 'Li' , 'free-streaming', 'LLRK4'}
-        The particle advance method to use. Code-specific method can be specified using 'other:<method>'. The default is code
-        dependent.
-
-        - 'Boris': Standard "leap-frog" Boris advance
-        - 'Vay':
-        - 'Higuera-Cary':
-        - 'Li' :
-        - 'free-streaming': Advance with no fields
-        - 'LLRK4': Landau-Lifschitz radiation reaction formula with RK-4)
-
-    charge_state: float, optional
-        Charge state of the species (applies only to atoms) [1]
-
-    charge: float, optional
-        Particle charge, required when type is not specified, otherwise determined from type [C]
-
-    mass: float, optional
-        Particle mass, required when type is not specified, otherwise determined from type [kg]
-
-    initial_distribution: distribution instance
-        The initial distribution loaded at t=0. Must be one of the standard distributions implemented.
-
-    density_scale: float, optional
-        A scale factor on the density given by the initial_distribution
-
-    particle_shape: {'NGP', 'linear', 'quadratic', 'cubic'}
-        Particle shape used for deposition and gather.
-        If not specified, the value from the `Simulation` object will be used.
-        Other values maybe specified that are code dependent.
+    The particle advance method options:
+    
+    - 'Boris': Standard "leap-frog" Boris advance
+    - 'Vay':
+    - 'Higuera-Cary':
+    - 'Li':
+    - 'free-streaming': Advance with no fields
+    - 'LLRK4': Landau-Lifschitz radiation reaction formula with RK-4)
     """
+    methods_list: list[str] = ['Boris', 'Vay', 'Higuera-Cary', 'Li', 'free-streaming', 'LLRK4']
 
-    methods_list = ['Boris' , 'Vay', 'Higuera-Cary', 'Li', 'free-streaming', 'LLRK4']
+    particle_type: str | None = Field(
+        default=None,
+        description="String, optional. A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md"
+    )
+    name: str | None = Field(
+        default=None,
+        description="String, optional. Name of the species"
+    )
+    method: str | None = Field(
+        default=None,
+        description="String, optional. The particle advance method to use. Code-specific method can be specified using 'other:<method>'. The default is code dependent. Must be one of 'Boris', 'Vay', 'Higuera-Cary', 'Li', 'free-streaming', 'LLRK4', or start with 'other:'"
+    )
+    charge_state: float | None = Field(
+        default=None,
+        description="Float, optional. Charge state of the species (applies only to atoms) [1]"
+    )
+    charge: float | None = Field(
+        default=None,
+        description="Float, optional. Particle charge, required when type is not specified, otherwise determined from type [C]"
+    )
+    mass: float | None = Field(
+        default=None,
+        description="Float, optional. Particle mass, required when type is not specified, otherwise determined from type [kg]"
+    )
+    initial_distribution: "PICMI_GaussianBunchDistribution | PICMI_UniformDistribution | PICMI_FoilDistribution | PICMI_AnalyticFluxDistribution | PICMI_AnalyticDistribution | PICMI_ParticleListDistribution | PICMI_FromFileDistribution | None" = Field(
+        default=None,
+        description="Distribution instance. The initial distribution loaded at t=0. Must be one of the standard distributions implemented."
+    )
+    density_scale: float | None = Field(
+        default=None,
+        description="Float, optional. A scale factor on the density given by the initial_distribution"
+    )
+    particle_shape: Literal['NGP', 'linear', 'quadratic', 'cubic'] | None = Field(
+        default=None,
+        description="String, optional. Particle shape used for deposition and gather. If not specified, the value from the Simulation object will be used. Other values maybe specified that are code dependent."
+    )
+    interactions: "list[PICMI_FieldIonization]" = Field(
+        default_factory=list,
+        exclude=True,
+        description="List of interactions for this species"
+    )
 
-    def __init__(self, particle_type=None, name=None, charge_state=None, charge=None, mass=None,
-                 initial_distribution=None, particle_shape=None, density_scale=None, method=None, **kw):
-
-
-        assert method is None or method in PICMI_Species.methods_list or method.startswith('other:'), \
-            Exception('method must starts with either "other:", or be one of the following '+', '.join(PICMI_Species.methods_list))
-
-        self.method = method
-        self.particle_type = particle_type
-        self.name = name
-        self.charge = charge
-        self.charge_state = charge_state
-        self.mass = mass
-        self.initial_distribution = initial_distribution
-        self.particle_shape = particle_shape
-        self.density_scale = density_scale
-
-        self.interactions = []
-
-        self.handle_init(kw)
+    @field_validator('method')
+    @classmethod
+    def _validate_method(cls, v):
+        if v is not None and v not in PICMI_Species.methods_list and not v.startswith('other:'):
+            raise ValueError(
+                f'method must start with either "other:", or be one of the following: {", ".join(PICMI_Species.methods_list)}'
+            )
+        return v
 
 
 class PICMI_MultiSpecies(_ClassWithInit):
     """
-    INCOMPLETE: proportions argument is not implemented
+    INCOMPLETE: proportions argument is not implemented.
     Multiple species that are initialized with the same distribution.
     Each parameter can be list, giving a value for each species, or a single value which is given to all species.
     The species charge and mass can be specified by setting the particle type or by setting them directly.
     If the particle type is specified, the charge or mass can be set to override the value from the type.
-
-    Parameters
-    ----------
-    particle_types: list of strings, optional
-        A string specifying an elementary particle, atom, or other, as defined in
-        the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md
-
-    names: list of strings, optional
-        Names of the species
-
-    charge_states: list of floats, optional
-        Charge states of the species (applies only to atoms)
-
-    charges: list of floats, optional
-        Particle charges, required when type is not specified, otherwise determined from type [C]
-
-    masses: list of floats, optional
-        Particle masses, required when type is not specified, otherwise determined from type [kg]
-
-    proportions: list of floats, optional
-        Proportions of the initial distribution made up by each species
-
-    initial_distribution: distribution instance
-        Initial particle distribution, applied to all species
-
-    particle_shape: {'NGP', 'linear', 'quadratic', 'cubic'}
-        Particle shape used for deposition and gather.
-        If not specified, the value from the `Simulation` object will be used.
-        Other values maybe specified that are code dependent.
     """
     # --- Note to developer: This class attribute needs to be set to the Species class
     # --- defined in the codes PICMI implementation.
-    Species_class = None
+    Species_class: type | None = None
 
-    def __init__(self, particle_types=None, names=None, charge_states=None, charges=None, masses=None,
-                 proportions=None, initial_distribution=None, particle_shape=None,
-                 **kw):
+    particle_types: str | Sequence[str] | None = Field(
+        default=None,
+        description="String or list of strings, optional. A string specifying an elementary particle, atom, or other, as defined in the openPMD 2 species type extension, openPMD-standard/EXT_SpeciesType.md"
+    )
+    names: str | Sequence[str] | None = Field(
+        default=None,
+        description="String or list of strings, optional. Names of the species"
+    )
+    charge_states: float | Sequence[float] | None = Field(
+        default=None,
+        description="Float or list of floats, optional. Charge states of the species (applies only to atoms)"
+    )
+    charges: float | Sequence[float] | None = Field(
+        default=None,
+        description="Float or list of floats, optional. Particle charges, required when type is not specified, otherwise determined from type [C]"
+    )
+    masses: float | Sequence[float] | None = Field(
+        default=None,
+        description="Float or list of floats, optional. Particle masses, required when type is not specified, otherwise determined from type [kg]"
+    )
+    proportions: float | Sequence[float] | None = Field(
+        default=None,
+        description="Float or list of floats, optional. Proportions of the initial distribution made up by each species"
+    )
+    initial_distribution: "PICMI_GaussianBunchDistribution | PICMI_UniformDistribution | PICMI_FoilDistribution | PICMI_AnalyticFluxDistribution | PICMI_AnalyticDistribution | PICMI_ParticleListDistribution | PICMI_FromFileDistribution | None" = Field(
+        default=None,
+        description="Distribution instance. Initial particle distribution, applied to all species"
+    )
+    particle_shape: Literal['NGP', 'linear', 'quadratic', 'cubic'] | None = Field(
+        default=None,
+        description="String, optional. Particle shape used for deposition and gather. If not specified, the value from the Simulation object will be used. Other values maybe specified that are code dependent."
+    )
+    nspecies: int | None = Field(
+        default=None,
+        exclude=True,
+        description="Number of species (computed from input parameters)"
+    )
+    species_instances_list: list[Any] = Field(
+        default_factory=list,
+        exclude=True,
+        description="List of species instances"
+    )
+    species_instances_dict: dict[str, Any] = Field(
+        default_factory=dict,
+        exclude=True,
+        description="Dictionary of species instances keyed by name"
+    )
 
-        self.particle_types = particle_types
-        self.names = names
-        self.charges = charges
-        self.charge_states = charge_states
-        self.masses = masses
-        self.proportions = proportions
-        self.initial_distribution = initial_distribution
-        self.particle_shape = particle_shape
-
+    @model_validator(mode='after')
+    def _create_species_instances(self) -> Self:
+        """Check nspecies consistency and create species instances"""
+        # Check nspecies consistency
         self.nspecies = None
-        self.check_nspecies(particle_types)
-        self.check_nspecies(names)
-        self.check_nspecies(charges)
-        self.check_nspecies(charge_states)
-        self.check_nspecies(masses)
-        self.check_nspecies(proportions)
+        self.check_nspecies(self.particle_types)
+        self.check_nspecies(self.names)
+        self.check_nspecies(self.charges)
+        self.check_nspecies(self.charge_states)
+        self.check_nspecies(self.masses)
+        self.check_nspecies(self.proportions)
 
-        # --- Create the instances of each species
+        if self.nspecies is None:
+            raise ValueError('At least one of particle_types, names, charges, charge_states, masses, or proportions must be specified')
+
+        # Create the instances of each species
         self.species_instances_list = []
         self.species_instances_dict = {}
         for i in range(self.nspecies):
-            particle_type = self.get_input_item(particle_types, i)
-            name = self.get_input_item(names, i)
-            charge = self.get_input_item(charges, i)
-            charge_state = self.get_input_item(charge_states, i)
-            mass = self.get_input_item(masses, i)
-            proportion = self.get_input_item(proportions, i)
-            specie = PICMI_MultiSpecies.Species_class(particle_type = particle_type,
-                                                      name = name,
-                                                      charge = charge,
-                                                      charge_state = charge_state,
-                                                      mass = mass,
-                                                      initial_distribution = initial_distribution,
-                                                      density_scale = proportion)
+            particle_type = self.get_input_item(self.particle_types, i)
+            name = self.get_input_item(self.names, i)
+            charge = self.get_input_item(self.charges, i)
+            charge_state = self.get_input_item(self.charge_states, i)
+            mass = self.get_input_item(self.masses, i)
+            proportion = self.get_input_item(self.proportions, i)
+            specie = PICMI_MultiSpecies.Species_class(
+                particle_type=particle_type,
+                name=name,
+                charge=charge,
+                charge_state=charge_state,
+                mass=mass,
+                initial_distribution=self.initial_distribution,
+                density_scale=proportion
+            )
             self.species_instances_list.append(specie)
             if name is not None:
                 self.species_instances_dict[name] = specie
 
-        self.handle_init(kw)
+        return self
 
     def check_nspecies(self, var):
         if var is not None:
@@ -176,7 +217,8 @@ class PICMI_MultiSpecies(_ClassWithInit):
                 nvars = len(var)
             except TypeError:
                 nvars = 1
-            assert self.nspecies is None or self.nspecies == nvars, Exception('All inputs must have the same length')
+            if self.nspecies is not None and self.nspecies != nvars:
+                raise ValueError('All inputs must have the same length')
             self.nspecies = nvars
 
     def get_input_item(self, var, i):
@@ -191,7 +233,7 @@ class PICMI_MultiSpecies(_ClassWithInit):
                 return var[i]
 
     def __len__(self):
-        return self.nspecies
+        return self.nspecies if self.nspecies is not None else 0
 
     def __getitem__(self, key):
         if isinstance(key, str):
@@ -203,275 +245,206 @@ class PICMI_MultiSpecies(_ClassWithInit):
 class PICMI_GaussianBunchDistribution(_ClassWithInit):
     """
     Describes a Gaussian distribution of particles
-
-    Parameters
-    ----------
-    n_physical_particles: integer
-        Number of physical particles in the bunch
-
-    rms_bunch_size: vector of length 3 of floats
-        RMS bunch size at t=0 [m]
-
-    rms_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        RMS velocity spread at t=0 [m/s]
-
-    centroid_position: vector of length 3 of floats, default=[0.,0.,0.]
-        Position of the bunch centroid at t=0 [m]
-
-    centroid_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        Velocity (gamma*V) of the bunch centroid at t=0 [m/s]
-
-    velocity_divergence: vector of length 3 of floats, default=[0.,0.,0.]
-        Expansion rate of the bunch at t=0 [m/s/m]
     """
-    def __init__(self,n_physical_particles, rms_bunch_size,
-                 rms_velocity = [0.,0.,0.],
-                 centroid_position = [0.,0.,0.],
-                 centroid_velocity = [0.,0.,0.],
-                 velocity_divergence = [0.,0.,0.],
-                 **kw):
-        self.n_physical_particles = n_physical_particles
-        self.rms_bunch_size = rms_bunch_size
-        self.rms_velocity = rms_velocity
-        self.centroid_position = centroid_position
-        self.centroid_velocity = centroid_velocity
-        self.velocity_divergence = velocity_divergence
-
-        self.handle_init(kw)
+    n_physical_particles: int = Field(
+        description="Integer. Number of physical particles in the bunch"
+    )
+    rms_bunch_size: Sequence[float] = Field(
+        description="Vector of length 3 of floats. RMS bunch size at t=0 [m]"
+    )
+    rms_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. RMS velocity spread at t=0 [m/s]"
+    )
+    centroid_position: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Position of the bunch centroid at t=0 [m]"
+    )
+    centroid_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Velocity (gamma*V) of the bunch centroid at t=0 [m/s]"
+    )
+    velocity_divergence: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Expansion rate of the bunch at t=0 [m/s/m]"
+    )
 
 
 class PICMI_UniformDistribution(_ClassWithInit):
     """
     Describes a uniform density distribution of particles
-
-    Parameters
-    ----------
-    density: float
-        Physical number density [m^-3]
-
-    lower_bound: vector of length 3 of floats, optional
-        Lower bound of the distribution [m]
-
-    upper_bound: vector of length 3 of floats, optional
-        Upper bound of the distribution [m]
-
-    rms_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        Thermal velocity spread [m/s]
-
-    directed_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        Directed, average, proper velocity [m/s]
-
-    fill_in: bool, optional
-        Flags whether to fill in the empty spaced opened up when the grid moves
     """
-
-    def __init__(self, density,
-                 lower_bound = [None,None,None],
-                 upper_bound = [None,None,None],
-                 rms_velocity = [0.,0.,0.],
-                 directed_velocity = [0.,0.,0.],
-                 fill_in = None,
-                 **kw):
-        self.density = density
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.rms_velocity = rms_velocity
-        self.directed_velocity = directed_velocity
-        self.fill_in = fill_in
-
-        self.handle_init(kw)
+    density: float = Field(
+        description="Float. Physical number density [m^-3]"
+    )
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Lower bound of the distribution [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Upper bound of the distribution [m]"
+    )
+    rms_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Thermal velocity spread [m/s]"
+    )
+    directed_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Directed, average, proper velocity [m/s]"
+    )
+    fill_in: bool | None = Field(
+        default=None,
+        description="Bool, optional. Flags whether to fill in the empty spaced opened up when the grid moves"
+    )
 
 
 class PICMI_FoilDistribution(_ClassWithInit):
     """
     Describes a foil with optional exponential pre- and post-plasma ramps along the propagation direction.
-
-    Parameters
-    ----------
-    density: float
-        Physical number density [m^-3]
-
-    front : float
-        postion of front surface of foil [m]
-
-    thickness: float >= 0
-        thickness of the foil [m]
-
-    exponential_pre_plasma_length: float > 0, optional
-        length scale of expoential decay of pre-foil plasma density [m]
-
-    exponential_pre_plasma_cutoff : float >= 0, optional
-        cutoff length for exponential decay of pre-foil density [m]
-
-    exponential_post_plasma_length: float > 0, optional
-        length scale of expoential decay of post-foil plasma density [m]
-
-    exponential_post_plasma_cutoff : float >= 0, optional
-        cutoff length for exponential decay of post-foil density [m]
-
-    lower_bound: vector of length 3 of floats, optional
-        Lower bound of the distribution [m]
-
-    upper_bound: vector of length 3 of floats, optional
-        Upper bound of the distribution [m]
-
-    rms_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        Thermal velocity spread [m/s]
-
-    directed_velocity: vector of length 3 of floats, default=[0.,0.,0.]
-        Directed, average, proper velocity [m/s]
-
-    fill_in: bool, optional
-        Flags whether to fill in the empty spaced opened up when the grid moves
     """
-
-    def __init__(self,
-                 density,
-                 front,
-                 thickness,
-                 rms_velocity = [0., 0., 0.],
-                 directed_velocity = [0., 0., 0.],
-                 lower_bound = [None,None,None],
-                 upper_bound = [None,None,None],
-                 exponential_pre_plasma_length = None,
-                 exponential_pre_plasma_cutoff = None,
-                 exponential_post_plasma_length = None,
-                 exponential_post_plasma_cutoff = None,
-                 fill_in = None,
-                 **kw) :
-        self.density = density
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.rms_velocity = rms_velocity
-        self.directed_velocity = directed_velocity
-        self.fill_in = fill_in
-
-        self.front = front
-        self.thickness = thickness
-        self.exponential_pre_plasma_length = exponential_pre_plasma_length
-        self.exponential_pre_plasma_cutoff = exponential_pre_plasma_cutoff
-        self.exponential_post_plasma_length = exponential_post_plasma_length
-        self.exponential_post_plasma_cutoff = exponential_post_plasma_cutoff
-
-        self.handle_init(kw)
+    density: float = Field(
+        description="Float. Physical number density [m^-3]"
+    )
+    front: float = Field(
+        description="Float. Position of front surface of foil [m]"
+    )
+    thickness: float = Field(
+        description="Float >= 0. Thickness of the foil [m]"
+    )
+    exponential_pre_plasma_length: float | None = Field(
+        default=None,
+        description="Float > 0, optional. Length scale of exponential decay of pre-foil plasma density [m]"
+    )
+    exponential_pre_plasma_cutoff: float | None = Field(
+        default=None,
+        description="Float >= 0, optional. Cutoff length for exponential decay of pre-foil density [m]"
+    )
+    exponential_post_plasma_length: float | None = Field(
+        default=None,
+        description="Float > 0, optional. Length scale of exponential decay of post-foil plasma density [m]"
+    )
+    exponential_post_plasma_cutoff: float | None = Field(
+        default=None,
+        description="Float >= 0, optional. Cutoff length for exponential decay of post-foil density [m]"
+    )
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Lower bound of the distribution [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Upper bound of the distribution [m]"
+    )
+    rms_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Thermal velocity spread [m/s]"
+    )
+    directed_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Directed, average, proper velocity [m/s]"
+    )
+    fill_in: bool | None = Field(
+        default=None,
+        description="Bool, optional. Flags whether to fill in the empty spaced opened up when the grid moves"
+    )
 
 
 class PICMI_AnalyticFluxDistribution(_ClassWithInit):
     """
-    Describes a flux of particles emitted from a plane
+    Describes a flux of particles emitted from a plane.
 
-    Parameters
-    ----------
-    flux: string
-        Analytic expression describing flux of particles [m^-2.s^-1]
-        Expression should be in terms of the position and time, written as 'x', 'y', 'z', and 't'.
-
-    flux_normal_axis: string
-        x, y, or z for 3D, x or z for 2D, or r, t, or z in RZ geometry
-
-    surface_flux_position: double
-        location of the injection plane [m] along the direction
-        specified by `flux_normal_axis`
-
-    flux_direction: int
-        Direction of the flux relative to the plane: -1 or +1
-
-    lower_bound: vector of floats, optional
-        Lower bound of the distribution [m]
-
-    upper_bound: vector of floats, optional
-        Upper bound of the distribution [m]
-
-    rms_velocity: vector of floats, default=[0.,0.,0.]
-        Thermal velocity spread [m/s]
-
-    directed_velocity: vector of floats, default=[0.,0.,0.]
-        Directed, average, proper velocity [m/s]
-
-    flux_tmin: float, optional
-        Time at which the flux injection will be turned on.
-
-    flux_tmax: float, optional
-        Time at which the flux injection will be turned off.
-
-    gaussian_flux_momentum_distribution: bool, optional
-        If True, the momentum distribution is v*Gaussian,
-        in the direction normal to the plane. Otherwise,
-        the momentum distribution is simply Gaussian.
+    The flux expression should be in terms of the position and time, written as 'x', 'y', 'z', and 't'.
+    Parameters can be used in the expression with the values given as keyword arguments.
     """
+    flux: str = Field(
+        description="String. Analytic expression describing flux of particles [m^-2.s^-1]. Expression should be in terms of the position and time, written as 'x', 'y', 'z', and 't'."
+    )
+    flux_normal_axis: str = Field(
+        description="String. x, y, or z for 3D, x or z for 2D, or r, t, or z in RZ geometry"
+    )
+    surface_flux_position: float = Field(
+        description="Float. Location of the injection plane [m] along the direction specified by flux_normal_axis"
+    )
+    flux_direction: int = Field(
+        description="Integer. Direction of the flux relative to the plane: -1 or +1"
+    )
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of floats, optional. Lower bound of the distribution [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of floats, optional. Upper bound of the distribution [m]"
+    )
+    rms_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of floats, default=[0.,0.,0.]. Thermal velocity spread [m/s]"
+    )
+    directed_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of floats, default=[0.,0.,0.]. Directed, average, proper velocity [m/s]"
+    )
+    flux_tmin: float | None = Field(
+        default=None,
+        description="Float, optional. Time at which the flux injection will be turned on"
+    )
+    flux_tmax: float | None = Field(
+        default=None,
+        description="Float, optional. Time at which the flux injection will be turned off"
+    )
+    gaussian_flux_momentum_distribution: bool | None = Field(
+        default=None,
+        description="Bool, optional. If True, the momentum distribution is v*Gaussian, in the direction normal to the plane. Otherwise, the momentum distribution is simply Gaussian."
+    )
+    user_defined_kw: dict[str, Any] = Field(
+        default_factory=dict,
+        exclude=True,
+        description="Dictionary of user-defined keyword arguments extracted from extra fields"
+    )
 
-    def __init__(self, flux, flux_normal_axis,
-                 surface_flux_position, flux_direction,
-                 lower_bound = [None,None,None],
-                 upper_bound = [None,None,None],
-                 rms_velocity = [0.,0.,0.],
-                 directed_velocity = [0.,0.,0.],
-                 flux_tmin = None,
-                 flux_tmax = None,
-                 gaussian_flux_momentum_distribution = None,
-                 **kw):
-        self.flux = f'{flux}'.replace('\n', '')
-        self.flux_normal_axis = flux_normal_axis
-        self.surface_flux_position = surface_flux_position
-        self.flux_direction = flux_direction
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.rms_velocity = rms_velocity
-        self.directed_velocity = directed_velocity
-        self.flux_tmin = flux_tmin
-        self.flux_tmax = flux_tmax
-        self.gaussian_flux_momentum_distribution = gaussian_flux_momentum_distribution
-
-        self.user_defined_kw = {}
-        for k in list(kw.keys()):
-            if re.search(r'\b%s\b'%k, self.flux):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-
-        self.handle_init(kw)
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_flux(cls, data: Any) -> Any:
+        """Normalize flux string and extract user-defined kwargs"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Normalize flux string
+        if 'flux' in data:
+            data['flux'] = f'{data["flux"]}'.replace('\n', '')
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _extract_user_defined_kw(self) -> Self:
+        """Extract user-defined keywords from extra fields"""
+        if self.model_extra:
+            flux_str = self.flux
+            self.user_defined_kw = {}
+            keys_to_remove = []
+            for k, v in self.model_extra.items():
+                if re.search(rf'\b{k}\b', flux_str):
+                    self.user_defined_kw[k] = v
+                    keys_to_remove.append(k)
+            # Remove extracted keys from model_extra
+            for k in keys_to_remove:
+                del self.model_extra[k]
+        
+        return self
 
 PICMI_UniformFluxDistribution = PICMI_AnalyticFluxDistribution
 
 class PICMI_AnalyticDistribution(_ClassWithInit):
     """
-    Describes a plasma with density following a provided analytic expression
+    Describes a plasma with density following a provided analytic expression.
 
-    Parameters
-    ----------
-    density_expression: string
-        Analytic expression describing physical number density (string) [m^-3].
-        Expression should be in terms of the position, written as 'x', 'y', and 'z'.
-        Parameters can be used in the expression with the values given as keyword arguments.
+    Expressions should be in terms of the position, written as 'x', 'y', and 'z'.
+    Parameters can be used in the expression with the values given as keyword arguments.
 
-    momentum_expressions: list of strings
-        Analytic expressions describing the gamma*velocity for each axis [m/s].
-        Expressions should be in terms of the position, written as 'x', 'y', and 'z'.
-        Parameters can be used in the expression with the values given as keyword arguments.
-        For any axis not supplied (set to None), directed_velocity will be used.
-
-    momentum_spread_expressions: list of strings
-        Analytic expressions describing the gamma*velocity Gaussian thermal spread sigma for each axis [m/s].
-        Expressions should be in terms of the position, written as 'x', 'y', and 'z'.
-        Parameters can be used in the expression with the values given as keyword arguments.
-        For any axis not supplied (set to None), zero will be used.
-
-    lower_bound: vector of length 3 of floats, optional
-        Lower bound of the distribution [m]
-
-    upper_bound: vector of length 3 of floats, optional
-        Upper bound of the distribution [m]
-
-    rms_velocity: vector of length 3 of floats, detault=[0.,0.,0.]
-        Thermal velocity spread [m/s]
-
-    directed_velocity: vector of length 3 of floats, detault=[0.,0.,0.]
-        Directed, average, proper velocity [m/s]
-
-    fill_in: bool, optional
-        Flags whether to fill in the empty spaced opened up when the grid moves
-
-
-    This example will create a distribution where the density is n0 below rmax and zero elsewhere.::
+    This example will create a distribution where the density is n0 below rmax and zero elsewhere::
 
     .. code-block:: python
 
@@ -479,126 +452,194 @@ class PICMI_AnalyticDistribution(_ClassWithInit):
                                   rmax = 1.,
                                   n0 = 1.e20,
                                   ...)
-
     """
+    density_expression: str = Field(
+        description="String. Analytic expression describing physical number density [m^-3]. Expression should be in terms of the position, written as 'x', 'y', and 'z'. Parameters can be used in the expression with the values given as keyword arguments."
+    )
+    momentum_expressions: Sequence[str | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="List of strings. Analytic expressions describing the gamma*velocity for each axis [m/s]. Expressions should be in terms of the position, written as 'x', 'y', and 'z'. Parameters can be used in the expression with the values given as keyword arguments. For any axis not supplied (set to None), directed_velocity will be used."
+    )
+    momentum_spread_expressions: Sequence[str | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="List of strings. Analytic expressions describing the gamma*velocity Gaussian thermal spread sigma for each axis [m/s]. Expressions should be in terms of the position, written as 'x', 'y', and 'z'. Parameters can be used in the expression with the values given as keyword arguments. For any axis not supplied (set to None), zero will be used."
+    )
+    lower_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Lower bound of the distribution [m]"
+    )
+    upper_bound: Sequence[float | None] = Field(
+        default_factory=lambda: [None, None, None],
+        description="Vector of length 3 of floats, optional. Upper bound of the distribution [m]"
+    )
+    rms_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Thermal velocity spread [m/s]"
+    )
+    directed_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Directed, average, proper velocity [m/s]"
+    )
+    fill_in: bool | None = Field(
+        default=None,
+        description="Bool, optional. Flags whether to fill in the empty spaced opened up when the grid moves"
+    )
+    user_defined_kw: dict[str, Any] = Field(
+        default_factory=dict,
+        exclude=True,
+        description="Dictionary of user-defined keyword arguments extracted from extra fields"
+    )
 
-    def __init__(self, density_expression,
-                 momentum_expressions = [None, None, None],
-                 momentum_spread_expressions = [None, None, None],
-                 lower_bound = [None,None,None],
-                 upper_bound = [None,None,None],
-                 rms_velocity = [0.,0.,0.],
-                 directed_velocity = [0.,0.,0.],
-                 fill_in = None,
-                 **kw):
-        self.density_expression = f'{density_expression}'.replace('\n', '')
-        self.momentum_expressions = momentum_expressions
-        self.momentum_spread_expressions = momentum_spread_expressions
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
-        self.rms_velocity = rms_velocity
-        self.directed_velocity = directed_velocity
-        self.fill_in = fill_in
-
-        # --- Convert momentum expressions to string if needed.
+    @model_validator(mode='before')
+    @classmethod
+    def _normalize_expressions(cls, data: Any) -> Any:
+        """Normalize expression strings"""
+        if not isinstance(data, dict):
+            return data
+        
+        data = dict(data)
+        
+        # Normalize density expression
+        if 'density_expression' in data:
+            data['density_expression'] = f'{data["density_expression"]}'.replace('\n', '')
+        
+        # Normalize momentum expressions
+        if 'momentum_expressions' in data and data['momentum_expressions']:
+            momentum_exprs = data['momentum_expressions']
+            for i in range(3):
+                if i < len(momentum_exprs) and momentum_exprs[i] is not None:
+                    momentum_exprs[i] = f'{momentum_exprs[i]}'.replace('\n', '')
+        
+        # Normalize momentum spread expressions
+        if 'momentum_spread_expressions' in data and data['momentum_spread_expressions']:
+            momentum_spread_exprs = data['momentum_spread_expressions']
+            for i in range(3):
+                if i < len(momentum_spread_exprs) and momentum_spread_exprs[i] is not None:
+                    momentum_spread_exprs[i] = f'{momentum_spread_exprs[i]}'.replace('\n', '')
+        
+        return data
+    
+    @model_validator(mode='after')
+    def _convert_expressions_and_extract_kw(self) -> Self:
+        """Convert momentum expressions to strings and extract user-defined keywords"""
+        # Convert momentum expressions to string if needed
         for idir in range(3):
             if self.momentum_expressions[idir] is not None:
                 self.momentum_expressions[idir] = f'{self.momentum_expressions[idir]}'.replace('\n', '')
             if self.momentum_spread_expressions[idir] is not None:
                 self.momentum_spread_expressions[idir] = f'{self.momentum_spread_expressions[idir]}'.replace('\n', '')
-
-        # --- Find any user defined keywords in the kw dictionary.
-        # --- Save them and delete them from kw.
-        # --- It's up to the code to make sure that all parameters
-        # --- used in the expression are defined.
-        self.user_defined_kw = {}
-        for k in list(kw.keys()):
-            if re.search(r'\b%s\b'%k, self.density_expression):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-            elif self.momentum_expressions[0] is not None and re.search(r'\b%s\b'%k, self.momentum_expressions[0]):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-            elif self.momentum_expressions[1] is not None and re.search(r'\b%s\b'%k, self.momentum_expressions[1]):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-            elif self.momentum_expressions[2] is not None and re.search(r'\b%s\b'%k, self.momentum_expressions[2]):
-                self.user_defined_kw[k] = kw[k]
-                del kw[k]
-
-        self.handle_init(kw)
+        
+        # Extract user-defined keywords from extra fields
+        if self.model_extra:
+            self.user_defined_kw = {}
+            keys_to_remove = []
+            
+            # Check density expression
+            for k, v in self.model_extra.items():
+                if re.search(rf'\b{k}\b', self.density_expression):
+                    self.user_defined_kw[k] = v
+                    keys_to_remove.append(k)
+                # Check momentum expressions
+                elif self.momentum_expressions[0] is not None and re.search(rf'\b{k}\b', self.momentum_expressions[0]):
+                    self.user_defined_kw[k] = v
+                    keys_to_remove.append(k)
+                elif self.momentum_expressions[1] is not None and re.search(rf'\b{k}\b', self.momentum_expressions[1]):
+                    self.user_defined_kw[k] = v
+                    keys_to_remove.append(k)
+                elif self.momentum_expressions[2] is not None and re.search(rf'\b{k}\b', self.momentum_expressions[2]):
+                    self.user_defined_kw[k] = v
+                    keys_to_remove.append(k)
+            
+            # Remove extracted keys from model_extra
+            for k in keys_to_remove:
+                del self.model_extra[k]
+        
+        return self
 
 
 class PICMI_ParticleListDistribution(_ClassWithInit):
     """
     Load particles at the specified positions and velocities
-
-    Parameters
-    ----------
-    x: float, default=0.
-        List of x positions of the particles [m]
-
-    y: float, default=0.
-        List of y positions of the particles [m]
-
-    z: float, default=0.
-        List of z positions of the particles [m]
-
-    ux: float, default=0.
-        List of ux positions of the particles (ux = gamma*vx) [m/s]
-
-    uy: float, default=0.
-        List of uy positions of the particles (uy = gamma*vy) [m/s]
-
-    uz: float, default=0.
-        List of uz positions of the particles (uz = gamma*vz) [m/s]
-
-    weight: float
-        Particle weight or list of weights, number of real particles per simulation particle
     """
-    def __init__(self, x=0., y=0., z=0., ux=0., uy=0., uz=0., weight=0.,
-                 **kw):
-        # --- Get length of arrays, set to one for scalars
-        lenx = np.size(x)
-        leny = np.size(y)
-        lenz = np.size(z)
-        lenux = np.size(ux)
-        lenuy = np.size(uy)
-        lenuz = np.size(uz)
-        lenw = np.size(weight)
+    x: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of x positions of the particles [m]"
+    )
+    y: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of y positions of the particles [m]"
+    )
+    z: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of z positions of the particles [m]"
+    )
+    ux: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of ux positions of the particles (ux = gamma*vx) [m/s]"
+    )
+    uy: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of uy positions of the particles (uy = gamma*vy) [m/s]"
+    )
+    uz: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. List of uz positions of the particles (uz = gamma*vz) [m/s]"
+    )
+    weight: float | Sequence[float] = Field(
+        default=0.,
+        description="Float or list of floats, default=0. Particle weight or list of weights, number of real particles per simulation particle"
+    )
+
+    @model_validator(mode='after')
+    def _normalize_arrays(self) -> Self:
+        """Normalize arrays: convert scalars to arrays and ensure all arrays have compatible lengths"""
+        # Get length of arrays, set to one for scalars
+        lenx = np.size(self.x)
+        leny = np.size(self.y)
+        lenz = np.size(self.z)
+        lenux = np.size(self.ux)
+        lenuy = np.size(self.uy)
+        lenuz = np.size(self.uz)
+        lenw = np.size(self.weight)
 
         maxlen = max(lenx, leny, lenz, lenux, lenuy, lenuz, lenw)
-        assert lenx==maxlen or lenx==1, "Length of x doesn't match len of others"
-        assert leny==maxlen or leny==1, "Length of y doesn't match len of others"
-        assert lenz==maxlen or lenz==1, "Length of z doesn't match len of others"
-        assert lenux==maxlen or lenux==1, "Length of ux doesn't match len of others"
-        assert lenuy==maxlen or lenuy==1, "Length of uy doesn't match len of others"
-        assert lenuz==maxlen or lenuz==1, "Length of uz doesn't match len of others"
-        assert lenw==maxlen or lenw==1, "Length of weight doesn't match len of others"
+        
+        if maxlen == 1:
+            # All scalars, nothing to do
+            return self
+        
+        # Validate lengths
+        if not (lenx == maxlen or lenx == 1):
+            raise ValueError("Length of x doesn't match len of others")
+        if not (leny == maxlen or leny == 1):
+            raise ValueError("Length of y doesn't match len of others")
+        if not (lenz == maxlen or lenz == 1):
+            raise ValueError("Length of z doesn't match len of others")
+        if not (lenux == maxlen or lenux == 1):
+            raise ValueError("Length of ux doesn't match len of others")
+        if not (lenuy == maxlen or lenuy == 1):
+            raise ValueError("Length of uy doesn't match len of others")
+        if not (lenuz == maxlen or lenuz == 1):
+            raise ValueError("Length of uz doesn't match len of others")
+        if not (lenw == maxlen or lenw == 1):
+            raise ValueError("Length of weight doesn't match len of others")
 
+        # Convert scalars to arrays
         if lenx == 1:
-            x = np.array(x)*np.ones(maxlen)
+            self.x = np.array(self.x) * np.ones(maxlen)
         if leny == 1:
-            y = np.array(y)*np.ones(maxlen)
+            self.y = np.array(self.y) * np.ones(maxlen)
         if lenz == 1:
-            z = np.array(z)*np.ones(maxlen)
+            self.z = np.array(self.z) * np.ones(maxlen)
         if lenux == 1:
-            ux = np.array(ux)*np.ones(maxlen)
+            self.ux = np.array(self.ux) * np.ones(maxlen)
         if lenuy == 1:
-            uy = np.array(uy)*np.ones(maxlen)
+            self.uy = np.array(self.uy) * np.ones(maxlen)
         if lenuz == 1:
-            uz = np.array(uz)*np.ones(maxlen,'d')
-        # --- Note that weight can be a scalar
+            self.uz = np.array(self.uz) * np.ones(maxlen, 'd')
+        # Note that weight can be a scalar (don't convert if lenw == 1)
 
-        self.weight = weight
-        self.x = x
-        self.y = y
-        self.z = z
-        self.ux = ux
-        self.uy = uy
-        self.uz = uz
-
-        self.handle_init(kw)
+        return self
 
 
 class PICMI_FromFileDistribution(_ClassWithInit):
@@ -607,9 +648,9 @@ class PICMI_FromFileDistribution(_ClassWithInit):
 
     The openPMD file must contain the attributes `position`, `momentum`, `weighting`.
     """
-    def __init__(self, file_path, **kw):
-        self.file_path = file_path
-        self.handle_init(kw)
+    file_path: str = Field(
+        description="String. Path to the openPMD file"
+    )
 
 # ------------------
 # Numeric Objects
@@ -619,78 +660,70 @@ class PICMI_FromFileDistribution(_ClassWithInit):
 class PICMI_ParticleDistributionPlanarInjector(_ClassWithInit):
     """
     Describes the injection of particles from a plane
-
-    Parameters
-    ----------
-    position: vector of length 3 of floats
-        Position of the particle centroid [m]
-
-    plane_normal: vector of length 3 of floats
-        Vector normal to the plane of injection [1]
-
-    plane_velocity: vector of length 3 of floats
-        Velocity of the plane of injection [m/s]
-
-    method: {'InPlace', 'Plane'}
     """
-    def __init__(self, position, plane_normal, plane_velocity=[0.,0.,0.], method='InPlace', **kw):
-        self.position = position
-        self.plane_normal = plane_normal
-        self.plane_velocity = plane_velocity
-        self.method = method
-
-        self.handle_init(kw)
+    position: Sequence[float] = Field(
+        description="Vector of length 3 of floats. Position of the particle centroid [m]"
+    )
+    plane_normal: Sequence[float] = Field(
+        description="Vector of length 3 of floats. Vector normal to the plane of injection [1]"
+    )
+    plane_velocity: Sequence[float] = Field(
+        default_factory=lambda: [0., 0., 0.],
+        description="Vector of length 3 of floats, default=[0.,0.,0.]. Velocity of the plane of injection [m/s]"
+    )
+    method: Literal['InPlace', 'Plane'] = Field(
+        default='InPlace',
+        description="String, default='InPlace'. Method: 'InPlace' or 'Plane'"
+    )
 
 
 class PICMI_GriddedLayout(_ClassWithInit):
     """
     Specifies a gridded layout of particles
-
-    Parameters
-    ----------
-    n_macroparticle_per_cell: vector of integers
-        Number of particles per cell along each axis
-
-    grid: grid instance, optional
-        Grid object specifying the grid to follow.
-        If not specified, the underlying grid of the code is used.
     """
-    def __init__(self, n_macroparticle_per_cell, grid=None, **kw):
-        self.n_macroparticle_per_cell = n_macroparticle_per_cell
-        self.grid = grid
-
-        self.handle_init(kw)
+    n_macroparticle_per_cell: Sequence[int] = Field(
+        description="Vector of integers. Number of particles per cell along each axis"
+    )
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid | None" = Field(
+        default=None,
+        description="Grid instance, optional. Grid object specifying the grid to follow. If not specified, the underlying grid of the code is used."
+    )
 
 
 class PICMI_PseudoRandomLayout(_ClassWithInit):
     """
     Specifies a pseudo-random layout of the particles
-
-    Parameters
-    ----------
-    n_macroparticles: integer
-        Total number of macroparticles to load.
-        Either this argument or n_macroparticles_per_cell should be supplied.
-
-    n_macroparticles_per_cell: integer
-        Number of macroparticles to load per cell.
-        Either this argument or n_macroparticles should be supplied.
-
-    seed: integer, optional
-        Pseudo-random number generator seed
-
-    grid: grid instance, optional
-        Grid object specifying the grid to follow for n_macroparticles_per_cell.
-        If not specified, the underlying grid of the code is used.
     """
-    def __init__(self, n_macroparticles=None, n_macroparticles_per_cell=None, seed=None, grid=None, **kw):
+    n_macroparticles: int | None = Field(
+        default=None,
+        description="Integer, optional. Total number of macroparticles to load. Either this argument or n_macroparticles_per_cell should be supplied (not both)."
+    )
+    n_macroparticles_per_cell: int | None = Field(
+        default=None,
+        description="Integer, optional. Number of macroparticles to load per cell. Either this argument or n_macroparticles should be supplied (not both)."
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Integer, optional. Pseudo-random number generator seed"
+    )
+    grid: "PICMI_Cartesian1DGrid | PICMI_Cartesian2DGrid | PICMI_Cartesian3DGrid | PICMI_CylindricalGrid | None" = Field(
+        default=None,
+        description="Grid instance, optional. Grid object specifying the grid to follow for n_macroparticles_per_cell. If not specified, the underlying grid of the code is used."
+    )
 
-        assert (n_macroparticles is not None)^(n_macroparticles_per_cell is not None), \
-               Exception('Only one of n_macroparticles and n_macroparticles_per_cell must be specified')
+    @model_validator(mode='after')
+    def _validate_either_or(self) -> Self:
+        if (self.n_macroparticles is None) == (self.n_macroparticles_per_cell is None):
+            raise ValueError('Exactly one of n_macroparticles or n_macroparticles_per_cell must be specified')
+        return self
 
-        self.n_macroparticles = n_macroparticles
-        self.n_macroparticles_per_cell = n_macroparticles_per_cell
-        self.seed = seed
-        self.grid = grid
-
-        self.handle_init(kw)
+# Define PICMI_Distribution type alias after all distribution classes are defined
+PICMI_Distribution = (
+    PICMI_GaussianBunchDistribution
+    | PICMI_UniformDistribution
+    | PICMI_FoilDistribution
+    | PICMI_AnalyticFluxDistribution
+    | PICMI_AnalyticDistribution
+    | PICMI_ParticleListDistribution
+    | PICMI_FromFileDistribution
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,22 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "picmistandard"
 dynamic = ["version"]
+requires-python = ">=3.10"
 dependencies = ["numpy>=1.15",
-                "scipy~=1.5"]
+                "scipy~=1.5",
+                "pydantic>=2.0",
+                "typing_extensions>=4.0; python_version<'3.11'"]
 description = "Python base classes for PICMI standard"
 readme = "README.md"
 license = {file = "License.txt"}
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Intended Audience :: Developers",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: User Interfaces"


### PR DESCRIPTION
Use a declarative approach to PICMI. Ensure construction & assignment to parameters both trigger validations. Ensure easier extensibility in downstream codes. Enable serialization, so people can easily query their PICMI options, e.g., in post-processing. Close #94

- [x] vibe code a draft, iterate and amend
- [x] ensure docs build well: [old](https://picmi.readthedocs.io/en/latest/standard/simulation.html) & [new](https://picmi--130.org.readthedocs.build/en/130/standard/simulation.html#)
- [ ] confirm it works with WarpX, doc extensions work
- [ ] confirm it works with FBPIC
- [ ] confirm it works with UCLA team (QuickPIC, QPAD?)
- [ ] confirm it works with PIConGPU team