### PR TITLE
Add run method to Simulation

### DIFF
--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -232,11 +232,9 @@ class PICMI_Simulation(_ClassWithInit):
 
     def run(self):
         """
-        Run the full simulation (typically up to max_step steps)
+        Run the full simulation (up to max_time or max_step are reached)
         """
         raise NotImplementedError
-
-
 
     def extension(self):
         """

--- a/PICMI_Python/simulation.py
+++ b/PICMI_Python/simulation.py
@@ -230,6 +230,14 @@ class PICMI_Simulation(_ClassWithInit):
         """
         raise NotImplementedError
 
+    def run(self):
+        """
+        Run the full simulation (typically up to max_step steps)
+        """
+        raise NotImplementedError
+
+
+
     def extension(self):
         """
         Reserved for code-specific extensions, for example returns a class instance


### PR DESCRIPTION
As discussed in the meeting adds an interface to run the full simulation. Given that this PR adds no functional code and only a single line of docstring, I'm sure we'll have at least 10 iterations bikeshedding over that one. I'll make a start: As I was not sure if there are use cases other than running `max_step` steps (e.g. running until a specified walltime, until a signal is received or a physical event happened in the simulation), I've put a "typically" in the docstring.